### PR TITLE
Alternative Function mapping for RCC MCO

### DIFF
--- a/data/af/PY32F002B.yaml
+++ b/data/af/PY32F002B.yaml
@@ -19,6 +19,13 @@ I2C1:
   - af: 6
     pin: PB6
     signal: SDA
+RCC:
+  - af: 4
+    pin: PA7
+    signal: MCO
+  - af: 4
+    pin: PB1
+    signal: MCO
 SPI1:
   - af: 0
     pin: PB0

--- a/data/af/PY32F030.yaml
+++ b/data/af/PY32F030.yaml
@@ -104,6 +104,28 @@ LPTIM1:
   - af: 5
     pin: PA5
     signal: ETR
+RCC:
+  - af: 15
+    pin: PA1
+    signal: MCO
+  - af: 15
+    pin: PA5
+    signal: MCO
+  - af: 5
+    pin: PA8
+    signal: MCO
+  - af: 5
+    pin: PA9
+    signal: MCO
+  - af: 15
+    pin: PA13
+    signal: MCO
+  - af: 15
+    pin: PA14
+    signal: MCO
+  - af: 6
+    pin: PF2
+    signal: MCO
 RTC:
   - af: 15
     pin: PA4

--- a/data/af/PY32F07X.yaml
+++ b/data/af/PY32F07X.yaml
@@ -170,6 +170,16 @@ I2S2:
   - af: 11
     pin: PC9
     signal: WS
+RCC:
+  - af: 0
+    pin: PA8
+    signal: MCO
+  - af: 9
+    pin: PA9
+    signal: MCO
+  - af: 9
+    pin: PB13
+    signal: MCO
 SPI1:
   - af: 8
     pin: PA1

--- a/data/af/PY32F403.yaml
+++ b/data/af/PY32F403.yaml
@@ -50,6 +50,10 @@ I2S2:
   - af: 15
     pin: PC6
     signal: MCK
+RCC:
+  - af: 0
+    pin: PA8
+    signal: MCO
 SPI1:
   - af: 3
     pin: PA4


### PR DESCRIPTION
I'm planning to enable clock output (MCO) in the RCC examples. For this we need the alternative function mapping.