### PR TITLE
Add UID for f002b and f030

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Date: 20240312
 
 - Set up configurations for cut-down variants such as PY32F003, PY32F002A, PY32F040.
 
+- The py32f07x reference manual does not describe the exact layout of the UID; it only specifies the base address (0x1FFF3000).  
+
 ## Contirbute
 
 You can refer to the relevant descriptions and explanations in[embassy-rs/stm32-data](https://github.com/embassy-rs/stm32-data) repo.

--- a/data/peripherals/F002B.yaml
+++ b/data/peripherals/F002B.yaml
@@ -368,8 +368,15 @@
       register: APBRSTR1
       field: DBGRST
 
-- name: CONFIGBYTES
+- name: UID
   address: 0x1FFF0000
+  registers:
+    kind: uid
+    version: v1
+    block: UID
+
+- name: CONFIGBYTES
+  address: 0x1FFF0100
   registers:
     kind: configbytes
     version: f002b

--- a/data/peripherals/F030.yaml
+++ b/data/peripherals/F030.yaml
@@ -572,6 +572,13 @@
       register: APBRSTR1
       field: DBGRST
 
+- name: UID
+  address: 0x1FFF0E00
+  registers:
+    kind: uid
+    version: v1
+    block: UID
+
 - name: CONFIGBYTES
   address: 0x1FFF0F00
   registers:

--- a/data/peripherals/F072.yaml
+++ b/data/peripherals/F072.yaml
@@ -775,6 +775,13 @@
   - signal: CH7
     interrupt: DMA1_Channel4_5_6_7
 
+- name:  UID
+  address: 0x1fff3000
+  registers:
+    kind: uid
+    version: v1
+    block: UID
+
 - name: CONFIGBYTES
   address: 0x1fff3200
   registers:

--- a/data/registers/configbytes_f002b.yaml
+++ b/data/registers/configbytes_f002b.yaml
@@ -3,12 +3,12 @@ block/CONFIGBYTES:
   items:
   - name: HSI_TRIMMING
     description: HSI 24 Hz frequency selection control and corresponding trimming value
-    byte_offset: 256
+    byte_offset: 0
     fieldset: HSI_TRIMMING
     access: Read
   - name: EPPARA
     description: FLASH configuration values. 24MHz.
-    byte_offset: 284
+    byte_offset: 28
     block: EPPARA
     access: Read
 

--- a/data/registers/uid_v1.yaml
+++ b/data/registers/uid_v1.yaml
@@ -1,0 +1,107 @@
+block/UID:
+  description: Unique Device ID.
+  items:
+  - name: WORD0
+    description: UID Word 0 (Offset 0x00).
+    byte_offset: 0
+    fieldset: UID_WORD0
+    access: Read
+  - name: WORD1
+    description: UID Word 1 (Offset 0x04).
+    byte_offset: 4
+    fieldset: UID_WORD1
+    access: Read
+  - name: WORD2
+    description: UID Word 2 (Offset 0x08).
+    byte_offset: 8
+    fieldset: UID_WORD2
+    access: Read
+  - name: WORD3
+    description: UID Word 3 (Offset 0x0C).
+    byte_offset: 12
+    fieldset: UID_WORD3
+    access: Read
+
+fieldset/UID_WORD0:
+  description: Lot Number (Bytes 0-3).
+  fields:
+  - name: LOT_NUM_ASCII_0
+    description: Lot Number ASCII Code (Byte 0).
+    bit_offset: 0
+    bit_size: 8
+  - name: LOT_NUM_ASCII_1
+    description: Lot Number ASCII Code (Byte 1).
+    bit_offset: 8
+    bit_size: 8
+  - name: LOT_NUM_ASCII_2
+    description: Lot Number ASCII Code (Byte 2).
+    bit_offset: 16
+    bit_size: 8
+  - name: LOT_NUM_ASCII_3
+    description: Lot Number ASCII Code (Byte 3).
+    bit_offset: 24
+    bit_size: 8
+
+fieldset/UID_WORD1:
+  description: Wafer Number and Lot Number (Bytes 4-7).
+  fields:
+  - name: WAFER_NUM
+    description: Wafer Number.
+    bit_offset: 0
+    bit_size: 8
+  - name: LOT_NUM_ASCII_4
+    description: Lot Number ASCII Code (Byte 4).
+    bit_offset: 8
+    bit_size: 8
+  - name: LOT_NUM_ASCII_5
+    description: Lot Number ASCII Code (Byte 5).
+    bit_offset: 16
+    bit_size: 8
+  - name: LOT_NUM_ASCII_6
+    description: Lot Number ASCII Code (Byte 6).
+    bit_offset: 24
+    bit_size: 8
+
+fieldset/UID_WORD2:
+  description: Coordinates and Internal Coding (Bytes 8-11).
+  fields:
+  - name: INTERNAL_CODE_0
+    description: Internal Coding (Byte 0).
+    bit_offset: 0
+    bit_size: 8
+  - name: Y_COORD_LOW
+    description: Y Coordinate Low bits.
+    bit_offset: 8
+    bit_size: 8
+  - name: X_COORD_LOW
+    description: X Coordinate Low bits.
+    bit_offset: 16
+    bit_size: 8
+  - name: X_COORD_HIGH
+    description: X Coordinate High bits.
+    bit_offset: 24
+    bit_size: 4
+  - name: Y_COORD_HIGH
+    description: Y Coordinate High bits.
+    bit_offset: 28
+    bit_size: 4
+
+fieldset/UID_WORD3:
+  description: Internal Coding and Fixed Code (Bytes 12-15).
+  fields:
+  - name: FIXED_CODE
+    description: Fixed Code (0x78).
+    bit_offset: 0
+    bit_size: 8
+  - name: INTERNAL_CODE_1
+    description: Internal Coding (Byte 1).
+    bit_offset: 8
+    bit_size: 8
+  - name: INTERNAL_CODE_2
+    description: Internal Coding (Byte 2).
+    bit_offset: 16
+    bit_size: 8
+  - name: INTERNAL_CODE_3
+    description: Internal Coding (Byte 3).
+    bit_offset: 24
+    bit_size: 8

--- a/data/registers/uid_v1.yaml
+++ b/data/registers/uid_v1.yaml
@@ -1,6 +1,17 @@
 block/UID:
   description: Unique Device ID.
   items:
+
+  # STM32-style UID registers
+  - name: UID
+    description: Factory programmed 96-bit unique device identifier words.
+    array:
+      len: 3
+      stride: 4
+    byte_offset: 0
+    access: Read
+
+  # Detailed UID registers
   - name: WORD0
     description: UID Word 0 (Offset 0x00).
     byte_offset: 0


### PR DESCRIPTION
The py32f07x reference manual does not describe the exact layout of the UID;
it only specifies the base address (0x1FFF3000).  