### PR TITLE
Correct GPIOCEN offset in 002B RCC IOPENR register

### DIFF
--- a/data/registers/rcc_f002b.yaml
+++ b/data/registers/rcc_f002b.yaml
@@ -424,7 +424,7 @@ fieldset/IOPENR:
     bit_size: 1
   - name: GPIOCEN
     description: I/O port C clock enable.
-    bit_offset: 5
+    bit_offset: 2
     bit_size: 1
 fieldset/IOPRSTR:
   description: GPIO reset register.


### PR DESCRIPTION
https://github.com/py32-rs/py32-hal/issues/46