### PR TITLE
Fix PY32F072 USB reset metadata

### DIFF
--- a/data/peripherals/F072.yaml
+++ b/data/peripherals/F072.yaml
@@ -733,7 +733,7 @@
     enable:
       register: APBENR1
       field: USBEN
-    disable:
+    reset:
       register: APBRSTR1
       field: USBRST
   interrupts:


### PR DESCRIPTION
I have an issue where the usb doesn't work when ran after flashing with the built in HID bootloader.
This doesn't seem to fix it, do you have any idea why?