### PR TITLE
Add MS32C001B support with dedicated DIE001B

### DIFF
--- a/d
+++ b/d
@@ -22,7 +22,7 @@ case "$CMD" in
         rm -rf tmp/$peri
         mkdir -p tmp/$peri
 
-        for f in `ls svd/PY32*`; do
+        for f in `ls svd/*.svd`; do
             echo $f
             svd_path=$f
             f=${f#"svd/PY32"}
@@ -47,6 +47,7 @@ case "$CMD" in
     ;;
     gen)
         rm -rf build/data
+        rm -rf build/py32-metapac/src
         cargo run -p py32-data-gen && cargo run -p py32-metapac-gen
     ;;
     ci)

--- a/d.ps1
+++ b/d.ps1
@@ -18,7 +18,7 @@ Switch ($CMD)
         rm -r -Force tmp/$peri -ErrorAction SilentlyContinue
         mkdir tmp/$peri | Out-Null
 
-        $files = Get-ChildItem -Path "svd/PY32*"
+        $files = Get-ChildItem -Path "svd/*.svd"
         foreach ($f in $files) {
             $svd_path = $f
             $f = $f.Name.TrimStart("svd/PY32").TrimEnd("xx.svd")
@@ -49,6 +49,7 @@ Switch ($CMD)
     }
     "gen" {
         Remove-Item -Recurse -Force "build/data" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force "build/py32-metapac/src" -ErrorAction SilentlyContinue
         cargo run -p py32-data-gen
         cargo run -p py32-metapac-gen
     }

--- a/data/chips/MS32C001BD14.yaml
+++ b/data/chips/MS32C001BD14.yaml
@@ -1,0 +1,7 @@
+name: MS32C001BD14
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BD14S7
+    package: SOP14
+    pins: 12

--- a/data/chips/MS32C001BF14.yaml
+++ b/data/chips/MS32C001BF14.yaml
@@ -1,0 +1,10 @@
+name: MS32C001BF14
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BF14P7
+    package: TSSOP20
+    pins: 18
+  - name: MS32C001BF14U7
+    package: QFN20
+    pins: 18

--- a/data/chips/MS32C001BF24.yaml
+++ b/data/chips/MS32C001BF24.yaml
@@ -1,0 +1,7 @@
+name: MS32C001BF24
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BF24U7
+    package: QFN20
+    pins: 18

--- a/data/chips/MS32C001BL14.yaml
+++ b/data/chips/MS32C001BL14.yaml
@@ -1,0 +1,7 @@
+name: MS32C001BL14
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BL14S7
+    package: SOP8
+    pins: 6

--- a/data/chips/MS32C001BW14.yaml
+++ b/data/chips/MS32C001BW14.yaml
@@ -1,0 +1,7 @@
+name: MS32C001BW14
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BW14S7
+    package: SOP16
+    pins: 14

--- a/data/chips/MS32C001BW24.yaml
+++ b/data/chips/MS32C001BW24.yaml
@@ -1,0 +1,7 @@
+name: MS32C001BW24
+generic: MS32C001Bx4
+device_id: 0
+packages:
+  - name: MS32C001BW24S7
+    package: SOP16
+    pins: 14

--- a/data/chips/MS32C001F14.yaml
+++ b/data/chips/MS32C001F14.yaml
@@ -1,0 +1,7 @@
+name: MS32C001F14
+generic: MS32C001x4
+device_id: 0
+packages:
+  - name: MS32C001F14U6
+    package: QFN20
+    pins: 18

--- a/data/chips/MS32C001W14.yaml
+++ b/data/chips/MS32C001W14.yaml
@@ -1,0 +1,7 @@
+name: MS32C001W14
+generic: MS32C001x4
+device_id: 0
+packages:
+  - name: MS32C001W14U6
+    package: QFN16
+    pins: 15

--- a/data/dies/DIE001B/af.yaml
+++ b/data/dies/DIE001B/af.yaml
@@ -1,0 +1,740 @@
+# GPIO alternate-function mappings for MS32C001B (per datasheet pin table 3-2 + AF tables).
+# EVENTOUT (PA6/PC0 AF7) is not modeled here: it has no peripheral backing it.
+# ADC analog channels (IN0-IN7) are listed without an af field (analog mode).
+DBGMCU:
+  - af: 0
+    pin: PA2
+    signal: SWCLK
+  - af: 0
+    pin: PB6
+    signal: SWDIO
+PWM1:
+  - af: 12
+    pin: PA0
+    signal: CH1
+  - af: 12
+    pin: PA1
+    signal: CH1
+  - af: 12
+    pin: PA2
+    signal: CH1
+  - af: 12
+    pin: PA3
+    signal: CH1
+  - af: 12
+    pin: PA4
+    signal: CH1
+  - af: 12
+    pin: PA5
+    signal: CH1
+  - af: 12
+    pin: PA6
+    signal: CH1
+  - af: 12
+    pin: PA7
+    signal: CH1
+  - af: 12
+    pin: PB0
+    signal: CH1
+  - af: 12
+    pin: PB1
+    signal: CH1
+  - af: 12
+    pin: PB2
+    signal: CH1
+  - af: 12
+    pin: PB3
+    signal: CH1
+  - af: 12
+    pin: PB4
+    signal: CH1
+  - af: 12
+    pin: PB5
+    signal: CH1
+  - af: 12
+    pin: PB6
+    signal: CH1
+  - af: 12
+    pin: PB7
+    signal: CH1
+  - af: 12
+    pin: PC0
+    signal: CH1
+  - af: 12
+    pin: PC1
+    signal: CH1
+RCC:
+  - af: 4
+    pin: PA7
+    signal: MCO
+  - af: 4
+    pin: PB1
+    signal: MCO
+TIM1:
+  - af: 1
+    pin: PB1
+    signal: CH2
+  - af: 1
+    pin: PC0
+    signal: CH3N
+  - af: 2
+    pin: PA0
+    signal: CH1
+  - af: 2
+    pin: PA1
+    signal: CH2
+  - af: 2
+    pin: PA2
+    signal: CH4
+  - af: 2
+    pin: PA3
+    signal: CH2
+  - af: 2
+    pin: PA4
+    signal: CH3
+  - af: 2
+    pin: PA5
+    signal: CH1
+  - af: 2
+    pin: PA6
+    signal: CH1
+  - af: 2
+    pin: PA7
+    signal: CH4
+  - af: 2
+    pin: PB0
+    signal: CH2
+  - af: 2
+    pin: PB1
+    signal: CH2N
+  - af: 2
+    pin: PB2
+    signal: CH1N
+  - af: 2
+    pin: PB3
+    signal: ETR
+  - af: 2
+    pin: PB4
+    signal: BKIN
+  - af: 2
+    pin: PB5
+    signal: CH3
+  - af: 2
+    pin: PB6
+    signal: CH1
+  - af: 2
+    pin: PB7
+    signal: CH1
+  - af: 2
+    pin: PC0
+    signal: CH1N
+  - af: 2
+    pin: PC1
+    signal: CH1
+  - af: 3
+    pin: PA0
+    signal: CH1N
+  - af: 3
+    pin: PA1
+    signal: CH1N
+  - af: 3
+    pin: PA2
+    signal: CH1N
+  - af: 3
+    pin: PA3
+    signal: CH1N
+  - af: 3
+    pin: PA4
+    signal: CH1N
+  - af: 3
+    pin: PA5
+    signal: CH1N
+  - af: 3
+    pin: PA6
+    signal: CH1N
+  - af: 3
+    pin: PB0
+    signal: CH3N
+  - af: 3
+    pin: PB1
+    signal: CH4
+  - af: 3
+    pin: PB2
+    signal: CH3
+  - af: 3
+    pin: PB3
+    signal: CH1N
+  - af: 3
+    pin: PB4
+    signal: CH1N
+  - af: 3
+    pin: PB5
+    signal: CH1N
+  - af: 3
+    pin: PB6
+    signal: CH1N
+  - af: 3
+    pin: PB7
+    signal: CH1N
+  - af: 3
+    pin: PC0
+    signal: CH1
+  - af: 3
+    pin: PC1
+    signal: CH1N
+  - af: 4
+    pin: PA0
+    signal: CH2
+  - af: 4
+    pin: PA1
+    signal: CH1
+  - af: 4
+    pin: PA2
+    signal: CH2
+  - af: 4
+    pin: PA3
+    signal: CH1
+  - af: 4
+    pin: PA4
+    signal: CH2
+  - af: 4
+    pin: PA5
+    signal: CH2
+  - af: 4
+    pin: PA6
+    signal: CH2
+  - af: 4
+    pin: PB0
+    signal: CH1
+  - af: 4
+    pin: PB2
+    signal: CH2
+  - af: 4
+    pin: PB3
+    signal: CH2
+  - af: 4
+    pin: PB4
+    signal: CH2
+  - af: 4
+    pin: PB5
+    signal: CH2
+  - af: 4
+    pin: PB6
+    signal: CH2
+  - af: 4
+    pin: PB7
+    signal: CH2
+  - af: 4
+    pin: PC0
+    signal: CH2
+  - af: 4
+    pin: PC1
+    signal: CH2
+  - af: 5
+    pin: PA0
+    signal: CH2N
+  - af: 5
+    pin: PA1
+    signal: CH2N
+  - af: 5
+    pin: PA2
+    signal: CH3
+  - af: 5
+    pin: PA3
+    signal: CH2N
+  - af: 5
+    pin: PA6
+    signal: CH2N
+  - af: 5
+    pin: PA7
+    signal: CH2N
+  - af: 5
+    pin: PB0
+    signal: CH2N
+  - af: 5
+    pin: PB1
+    signal: CH1
+  - af: 5
+    pin: PB2
+    signal: CH2N
+  - af: 5
+    pin: PB3
+    signal: CH2N
+  - af: 5
+    pin: PB4
+    signal: CH2N
+  - af: 5
+    pin: PB6
+    signal: CH2N
+  - af: 5
+    pin: PC0
+    signal: CH2N
+  - af: 5
+    pin: PC1
+    signal: CH2N
+  - af: 6
+    pin: PA0
+    signal: CH3
+  - af: 6
+    pin: PA1
+    signal: CH3
+  - af: 6
+    pin: PA2
+    signal: CH3
+  - af: 6
+    pin: PA3
+    signal: CH3
+  - af: 6
+    pin: PA4
+    signal: CH1
+  - af: 6
+    pin: PA5
+    signal: CH3
+  - af: 6
+    pin: PA6
+    signal: CH3
+  - af: 6
+    pin: PA7
+    signal: CH3
+  - af: 6
+    pin: PB0
+    signal: CH3
+  - af: 6
+    pin: PB1
+    signal: CH3
+  - af: 6
+    pin: PB2
+    signal: CH1
+  - af: 6
+    pin: PB3
+    signal: CH3
+  - af: 6
+    pin: PB4
+    signal: CH3
+  - af: 6
+    pin: PB5
+    signal: CH1
+  - af: 6
+    pin: PB6
+    signal: CH3
+  - af: 6
+    pin: PB7
+    signal: CH3
+  - af: 6
+    pin: PC0
+    signal: CH3
+  - af: 6
+    pin: PC1
+    signal: CH3
+  - af: 7
+    pin: PA0
+    signal: CH3N
+  - af: 7
+    pin: PA1
+    signal: CH3N
+  - af: 7
+    pin: PA2
+    signal: CH3N
+  - af: 7
+    pin: PA3
+    signal: CH3N
+  - af: 7
+    pin: PA4
+    signal: CH3N
+  - af: 7
+    pin: PA5
+    signal: CH3N
+  - af: 7
+    pin: PA7
+    signal: CH3N
+  - af: 7
+    pin: PB0
+    signal: CH1N
+  - af: 7
+    pin: PB1
+    signal: CH3N
+  - af: 7
+    pin: PB2
+    signal: CH3N
+  - af: 7
+    pin: PB3
+    signal: CH3N
+  - af: 7
+    pin: PB4
+    signal: CH3N
+  - af: 7
+    pin: PB5
+    signal: CH3N
+  - af: 7
+    pin: PB6
+    signal: CH3N
+  - af: 7
+    pin: PB7
+    signal: CH3N
+  - af: 7
+    pin: PC1
+    signal: CH3N
+  - af: 8
+    pin: PA0
+    signal: CH4
+  - af: 8
+    pin: PA1
+    signal: CH4
+  - af: 8
+    pin: PA2
+    signal: CH1
+  - af: 8
+    pin: PA3
+    signal: CH4
+  - af: 8
+    pin: PA4
+    signal: CH4
+  - af: 8
+    pin: PA5
+    signal: CH4
+  - af: 8
+    pin: PA6
+    signal: CH4
+  - af: 8
+    pin: PA7
+    signal: CH2
+  - af: 8
+    pin: PB0
+    signal: CH4
+  - af: 8
+    pin: PB1
+    signal: CH1N
+  - af: 8
+    pin: PB2
+    signal: CH4
+  - af: 8
+    pin: PB3
+    signal: CH4
+  - af: 8
+    pin: PB4
+    signal: CH4
+  - af: 8
+    pin: PB5
+    signal: CH4
+  - af: 8
+    pin: PB6
+    signal: CH4
+  - af: 8
+    pin: PB7
+    signal: CH4
+  - af: 8
+    pin: PC0
+    signal: CH4
+  - af: 8
+    pin: PC1
+    signal: CH4
+  - af: 9
+    pin: PA0
+    signal: BKIN
+  - af: 9
+    pin: PA1
+    signal: BKIN
+  - af: 9
+    pin: PA2
+    signal: BKIN
+  - af: 9
+    pin: PA3
+    signal: BKIN
+  - af: 9
+    pin: PA4
+    signal: BKIN
+  - af: 9
+    pin: PA5
+    signal: BKIN
+  - af: 9
+    pin: PA6
+    signal: BKIN
+  - af: 9
+    pin: PA7
+    signal: BKIN
+  - af: 9
+    pin: PB0
+    signal: BKIN
+  - af: 9
+    pin: PB1
+    signal: BKIN
+  - af: 9
+    pin: PB2
+    signal: BKIN
+  - af: 9
+    pin: PB3
+    signal: BKIN
+  - af: 9
+    pin: PB4
+    signal: CH1
+  - af: 9
+    pin: PB5
+    signal: BKIN
+  - af: 9
+    pin: PB6
+    signal: BKIN
+  - af: 9
+    pin: PB7
+    signal: BKIN
+  - af: 9
+    pin: PC0
+    signal: BKIN
+  - af: 9
+    pin: PC1
+    signal: BKIN
+  - af: 10
+    pin: PA0
+    signal: ETR
+  - af: 10
+    pin: PA1
+    signal: ETR
+  - af: 10
+    pin: PA2
+    signal: ETR
+  - af: 10
+    pin: PA3
+    signal: ETR
+  - af: 10
+    pin: PA4
+    signal: ETR
+  - af: 10
+    pin: PA5
+    signal: ETR
+  - af: 10
+    pin: PA6
+    signal: ETR
+  - af: 10
+    pin: PA7
+    signal: ETR
+  - af: 10
+    pin: PB0
+    signal: ETR
+  - af: 10
+    pin: PB1
+    signal: ETR
+  - af: 10
+    pin: PB2
+    signal: ETR
+  - af: 10
+    pin: PB3
+    signal: ETR
+  - af: 10
+    pin: PB4
+    signal: ETR
+  - af: 10
+    pin: PB5
+    signal: ETR
+  - af: 10
+    pin: PB6
+    signal: ETR
+  - af: 10
+    pin: PB7
+    signal: ETR
+  - af: 10
+    pin: PC0
+    signal: ETR
+  - af: 10
+    pin: PC1
+    signal: ETR
+  - af: 11
+    pin: PA4
+    signal: CH2N
+  - af: 11
+    pin: PA5
+    signal: CH2N
+  - af: 11
+    pin: PB5
+    signal: CH2N
+  - af: 11
+    pin: PB7
+    signal: CH2N
+  - af: 13
+    pin: PA6
+    signal: CH3N
+  - af: 13
+    pin: PA7
+    signal: CH1
+  - af: 14
+    pin: PA7
+    signal: CH1N
+TIM14:
+  - af: 5
+    pin: PA4
+    signal: CH1
+  - af: 5
+    pin: PA5
+    signal: CH1
+  - af: 5
+    pin: PB5
+    signal: CH1
+  - af: 5
+    pin: PB7
+    signal: CH1
+  - af: 11
+    pin: PA0
+    signal: CH1
+  - af: 11
+    pin: PA1
+    signal: CH1
+  - af: 11
+    pin: PA2
+    signal: CH1
+  - af: 11
+    pin: PA3
+    signal: CH1
+  - af: 11
+    pin: PA6
+    signal: CH1
+  - af: 11
+    pin: PA7
+    signal: CH1
+  - af: 11
+    pin: PB0
+    signal: CH1
+  - af: 11
+    pin: PB1
+    signal: CH1
+  - af: 11
+    pin: PB2
+    signal: CH1
+  - af: 11
+    pin: PB3
+    signal: CH1
+  - af: 11
+    pin: PB4
+    signal: CH1
+  - af: 11
+    pin: PB6
+    signal: CH1
+  - af: 11
+    pin: PC0
+    signal: CH1
+  - af: 11
+    pin: PC1
+    signal: CH1
+UART1:
+  - af: 1
+    pin: PA2
+    signal: RX
+  - af: 1
+    pin: PA3
+    signal: TX
+  - af: 1
+    pin: PA4
+    signal: RX
+  - af: 1
+    pin: PA6
+    signal: TX
+  - af: 1
+    pin: PA7
+    signal: TX
+  - af: 1
+    pin: PB4
+    signal: TX
+  - af: 1
+    pin: PB5
+    signal: RX
+  - af: 1
+    pin: PB6
+    signal: TX
+  - af: 3
+    pin: PA7
+    signal: RX
+  - af: 13
+    pin: PA0
+    signal: TX
+  - af: 13
+    pin: PA1
+    signal: TX
+  - af: 13
+    pin: PA2
+    signal: TX
+  - af: 13
+    pin: PA4
+    signal: TX
+  - af: 13
+    pin: PA5
+    signal: TX
+  - af: 13
+    pin: PB0
+    signal: TX
+  - af: 13
+    pin: PB1
+    signal: TX
+  - af: 13
+    pin: PB2
+    signal: TX
+  - af: 13
+    pin: PB3
+    signal: TX
+  - af: 13
+    pin: PB5
+    signal: TX
+  - af: 13
+    pin: PB7
+    signal: TX
+  - af: 13
+    pin: PC0
+    signal: TX
+  - af: 13
+    pin: PC1
+    signal: TX
+  - af: 14
+    pin: PA0
+    signal: RX
+  - af: 14
+    pin: PA1
+    signal: RX
+  - af: 14
+    pin: PA3
+    signal: RX
+  - af: 14
+    pin: PA5
+    signal: RX
+  - af: 14
+    pin: PA6
+    signal: RX
+  - af: 14
+    pin: PB0
+    signal: RX
+  - af: 14
+    pin: PB1
+    signal: RX
+  - af: 14
+    pin: PB2
+    signal: RX
+  - af: 14
+    pin: PB3
+    signal: RX
+  - af: 14
+    pin: PB4
+    signal: RX
+  - af: 14
+    pin: PB6
+    signal: RX
+  - af: 14
+    pin: PB7
+    signal: RX
+  - af: 14
+    pin: PC0
+    signal: RX
+  - af: 14
+    pin: PC1
+    signal: RX
+ADC1:
+  - pin: PB1
+    signal: IN0
+  - pin: PA3
+    signal: IN1
+  - pin: PA4
+    signal: IN2
+  - pin: PA6
+    signal: IN3
+  - pin: PA7
+    signal: IN4
+  - pin: PC0
+    signal: IN5
+  - pin: PA0
+    signal: IN6
+  - pin: PB0
+    signal: IN7

--- a/data/dies/DIE001B/interrupts.yaml
+++ b/data/dies/DIE001B/interrupts.yaml
@@ -1,0 +1,30 @@
+# Interrupt vector table per CMSIS device header (ms32c001bx4.h) and
+# startup_ms32c001bxx.s from MS32C001B__Firmware_V0.5.0 / DFP 1.0.6.
+# NOTE: The SVD's interrupt numbers are stale copies of the MS32C001 table
+# and must NOT be used here.
+- name: PVD
+  number: 0
+- name: FLASH
+  number: 1
+- name: RCC
+  number: 2
+- name: EXTI0_1
+  number: 3
+- name: EXTI2_3
+  number: 4
+- name: EXTI4_7
+  number: 5
+- name: ADC1
+  number: 8
+- name: TIM1_BRK_UP_TRG_COM
+  number: 9
+- name: TIM1_CC
+  number: 10
+- name: LPTIM1
+  number: 11
+- name: TIM14
+  number: 12
+- name: PWM1
+  number: 16
+- name: UART1
+  number: 17

--- a/data/dies/DIE001B/peripherals.yaml
+++ b/data/dies/DIE001B/peripherals.yaml
@@ -1,0 +1,313 @@
+- name: UID
+  address: 536805376
+  registers:
+    kind: uid
+    version: v1
+    block: UID
+
+- name: CONFIGBYTES
+  address: 536805440
+  registers:
+    kind: configbytes
+    version: ms32c001b
+    block: CONFIGBYTES
+
+- name: TIM14
+  address: 0x40002000
+  registers:
+    kind: timer
+    version: v1b
+    block: TIM_1CH
+  rcc:
+    bus_clock: PCLK1_TIM
+    kernel_clock: PCLK1_TIM
+    enable:
+      register: APBENR2
+      field: TIM14EN
+    reset:
+      register: APBRSTR2
+      field: TIM14RST
+  interrupts:
+  - signal: UP
+    interrupt: TIM14
+  - signal: CC
+    interrupt: TIM14
+
+- name: PWM1
+  address: 0x40002800
+  registers:
+    kind: pwm
+    version: v1
+    block: PWM
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR2
+      field: PWMEN
+    reset:
+      register: APBRSTR2
+      field: PWMRST
+  interrupts:
+  - signal: GLOBAL
+    interrupt: PWM1
+
+- name: IWDG
+  address: 0x40003000
+  registers:
+    kind: iwdg
+    version: common
+    block: IWDG
+
+- name: UART1
+  address: 0x40004800
+  registers:
+    kind: usart
+    version: v2
+    block: UART
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR1
+      field: UART1EN
+    reset:
+      register: APBRSTR1
+      field: UART1RST
+  interrupts:
+  - signal: GLOBAL
+    interrupt: UART1
+
+- name: PWR
+  address: 0x40007000
+  registers:
+    kind: pwr
+    version: common
+    block: PWR
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR1
+      field: PWREN
+    reset:
+      register: APBRSTR1
+      field: PWRRST
+  interrupts:
+  - signal: GLOBAL
+    interrupt: PVD
+
+- name: LPTIM
+  address: 0x40007c00
+  registers:
+    kind: lptim
+    version: common
+    block: LPTIM
+  rcc:
+    bus_clock: PCLK1_TIM
+    kernel_clock: PCLK1_TIM
+    enable:
+      register: APBENR1
+      field: LPTIMEN
+    reset:
+      register: APBRSTR1
+      field: LPTIMRST
+  interrupts:
+  - signal: GLOBAL
+    interrupt: LPTIM1
+
+- name: SYSCFG
+  address: 0x40010000
+  registers:
+    kind: syscfg
+    version: f002b
+    block: SYSCFG
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR2
+      field: SYSCFGEN
+    reset:
+      register: APBRSTR2
+      field: SYSCFGRST
+
+- name: VREF
+  address: 0x40010100
+  registers:
+    kind: vref
+    version: v1
+    block: VREF
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR2
+      field: VREFBUFEN
+    reset:
+      register: APBRSTR2
+      field: VREFBUFRST
+
+- name: ADC1
+  address: 0x40012400
+  registers:
+    kind: adc
+    version: v3
+    block: ADC
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR2
+      field: ADCEN
+    reset:
+      register: APBRSTR2
+      field: ADCRST
+  interrupts:
+  - signal: GLOBAL
+    interrupt: ADC1
+
+- name: TIM1
+  address: 0x40012c00
+  registers:
+    kind: timer
+    version: v1b
+    block: TIM_ADV
+  rcc:
+    bus_clock: PCLK1_TIM
+    kernel_clock: PCLK1_TIM
+    enable:
+      register: APBENR2
+      field: TIM1EN
+    reset:
+      register: APBRSTR2
+      field: TIM1RST
+  interrupts:
+  - signal: BRK
+    interrupt: TIM1_BRK_UP_TRG_COM
+  - signal: UP
+    interrupt: TIM1_BRK_UP_TRG_COM
+  - signal: TRG
+    interrupt: TIM1_BRK_UP_TRG_COM
+  - signal: COM
+    interrupt: TIM1_BRK_UP_TRG_COM
+  - signal: CC
+    interrupt: TIM1_CC
+
+- name: DBGMCU
+  address: 0x40015800
+  registers:
+    kind: dbgmcu
+    version: f002b
+    block: DBGMCU
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: APBENR1
+      field: DBGEN
+    reset:
+      register: APBRSTR1
+      field: DBGRST
+
+- name: RCC
+  address: 0x40021000
+  registers:
+    kind: rcc
+    version: ms32c001b
+    block: RCC
+  interrupts:
+  - signal: GLOBAL
+    interrupt: RCC
+
+- name: EXTI
+  address: 0x40021800
+  registers:
+    kind: exti
+    version: v1b
+    block: EXTI
+  interrupts:
+  - signal: EXTI0
+    interrupt: EXTI0_1
+  - signal: EXTI1
+    interrupt: EXTI0_1
+  - signal: EXTI2
+    interrupt: EXTI2_3
+  - signal: EXTI3
+    interrupt: EXTI2_3
+  - signal: EXTI4
+    interrupt: EXTI4_7
+  - signal: EXTI5
+    interrupt: EXTI4_7
+  - signal: EXTI6
+    interrupt: EXTI4_7
+  - signal: EXTI7
+    interrupt: EXTI4_7
+  - signal: EXTI16
+    interrupt: PVD
+  - signal: EXTI29
+    interrupt: LPTIM1
+
+- name: FLASH
+  address: 0x40022000
+  registers:
+    kind: flash
+    version: ms32c001b
+    block: FLASH
+  rcc:
+    bus_clock: HCLK1
+    kernel_clock: HCLK1
+    enable:
+      register: AHBENR
+      field: FLASHEN
+  interrupts:
+  - signal: GLOBAL
+    interrupt: FLASH
+
+- name: GPIOA
+  address: 0x50000000
+  registers:
+    kind: gpio
+    version: v1b
+    block: GPIO
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: IOPENR
+      field: GPIOAEN
+    reset:
+      register: IOPRSTR
+      field: GPIOARST
+
+- name: GPIOB
+  address: 0x50000400
+  registers:
+    kind: gpio
+    version: v1b
+    block: GPIO
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: IOPENR
+      field: GPIOBEN
+    reset:
+      register: IOPRSTR
+      field: GPIOBRST
+
+- name: GPIOC
+  address: 0x50000800
+  registers:
+    kind: gpio
+    version: v1b
+    block: GPIO
+  rcc:
+    bus_clock: PCLK1
+    kernel_clock: PCLK1
+    enable:
+      register: IOPENR
+      field: GPIOCEN
+    reset:
+      register: IOPRSTR
+      field: GPIOCRST

--- a/data/generics/MS32C001Bx4.yaml
+++ b/data/generics/MS32C001Bx4.yaml
@@ -1,0 +1,14 @@
+series: MS32C001B
+memory:
+- address: 134217728
+  kind: flash
+  name: BANK_1
+  settings:
+    sector_size: 1024
+    erase_value: 0
+    page_size: 64
+  size: 16384
+- address: 536870912
+  kind: ram
+  name: SRAM
+  size: 2048

--- a/data/generics/MS32C001x4.yaml
+++ b/data/generics/MS32C001x4.yaml
@@ -1,0 +1,14 @@
+series: MS32C001
+memory:
+- address: 134217728
+  kind: flash
+  name: BANK_1
+  settings:
+    sector_size: 4096
+    erase_value: 0
+    page_size: 128
+  size: 18432
+- address: 536870912
+  kind: ram
+  name: SRAM
+  size: 1536

--- a/data/registers/adc_v3.yaml
+++ b/data/registers/adc_v3.yaml
@@ -1,0 +1,326 @@
+block/ADC:
+  description: Analog to Digital Converter
+  items:
+  - name: ISR
+    description: ADC interrupt and status register
+    byte_offset: 0
+    fieldset: ISR
+  - name: IER
+    description: ADC interrupt enable register
+    byte_offset: 4
+    fieldset: IER
+  - name: CR
+    description: ADC control register
+    byte_offset: 8
+    fieldset: CR
+  - name: CFGR1
+    description: ADC configuration register 1
+    byte_offset: 12
+    fieldset: CFGR1
+  - name: CFGR2
+    description: ADC configuration register 2
+    byte_offset: 16
+    fieldset: CFGR2
+  - name: SMPR
+    description: ADC sampling time register
+    byte_offset: 20
+    fieldset: SMPR
+  - name: TR
+    description: ADC analog watchdog 1 threshold register
+    byte_offset: 24
+    fieldset: TR
+  - name: SQR1
+    description: ADC regular sequence register 1
+    byte_offset: 28
+    fieldset: SQR1
+  - name: SQR2
+    description: ADC regular sequence register 2
+    byte_offset: 32
+    fieldset: SQR2
+  - name: SQR3
+    description: ADC regular sequence register 3
+    byte_offset: 36
+    fieldset: SQR3
+  - name: DR
+    description: ADC regular data register
+    byte_offset: 40
+    fieldset: DR
+  - name: CALFACT
+    description: ADC calibration factor register
+    byte_offset: 68
+    fieldset: CALFACT
+  - name: CCR
+    description: ADC common configuration register
+    byte_offset: 72
+    fieldset: CCR
+fieldset/CALFACT:
+  description: ADC calibration factor register
+  fields:
+  - name: WCALFACT
+    description: Write calibration factor
+    bit_offset: 0
+    bit_size: 9
+  - name: FACTSEL
+    description: Factor selection
+    bit_offset: 9
+    bit_size: 5
+  - name: WRVLD
+    description: Write valid
+    bit_offset: 14
+    bit_size: 1
+  - name: RDVLD
+    description: Read valid
+    bit_offset: 15
+    bit_size: 1
+  - name: CAPSUC
+    description: Calibration success
+    bit_offset: 21
+    bit_size: 1
+  - name: RCALFACT
+    description: Read calibration factor
+    bit_offset: 23
+    bit_size: 9
+fieldset/CCR:
+  description: ADC common configuration register
+  fields:
+  - name: VREFEN
+    description: VREFINT enable
+    bit_offset: 22
+    bit_size: 1
+  - name: TSEN
+    description: Temperature sensor enable
+    bit_offset: 23
+    bit_size: 1
+  - name: VREFSEL
+    description: VREF selection
+    bit_offset: 24
+    bit_size: 1
+  - name: PWRMODE
+    description: Power mode
+    bit_offset: 25
+    bit_size: 3
+fieldset/CFGR1:
+  description: ADC configuration register 1
+  fields:
+  - name: RES
+    description: Data resolution
+    bit_offset: 3
+    bit_size: 2
+  - name: ALIGN
+    description: Data alignment
+    bit_offset: 5
+    bit_size: 1
+  - name: EXTSEL
+    description: External trigger selection
+    bit_offset: 6
+    bit_size: 3
+  - name: EXTEN
+    description: External trigger enable and polarity selection
+    bit_offset: 10
+    bit_size: 2
+  - name: OVRMOD
+    description: Overrun management mode
+    bit_offset: 12
+    bit_size: 1
+  - name: CONT
+    description: Continuous conversion mode
+    bit_offset: 13
+    bit_size: 1
+  - name: WAIT
+    description: Wait conversion mode
+    bit_offset: 14
+    bit_size: 1
+  - name: DISCEN
+    description: Discontinuous mode enable
+    bit_offset: 16
+    bit_size: 1
+  - name: CALNUM
+    description: Number of calibration samples
+    bit_offset: 17
+    bit_size: 3
+  - name: AWDSGL
+    description: Analog watchdog single channel enable
+    bit_offset: 22
+    bit_size: 1
+  - name: AWDEN
+    description: Analog watchdog enable
+    bit_offset: 23
+    bit_size: 1
+  - name: AWDCH
+    description: Analog watchdog channel selection
+    bit_offset: 26
+    bit_size: 4
+fieldset/CFGR2:
+  description: ADC configuration register 2
+  fields:
+  - name: CKMODE
+    description: ADC clock mode
+    bit_offset: 28
+    bit_size: 4
+fieldset/CR:
+  description: ADC control register
+  fields:
+  - name: ADEN
+    description: ADC enable
+    bit_offset: 0
+    bit_size: 1
+  - name: ADDIS
+    description: ADC disable
+    bit_offset: 1
+    bit_size: 1
+  - name: ADSTART
+    description: ADC start conversion
+    bit_offset: 2
+    bit_size: 1
+  - name: ADSTP
+    description: ADC stop conversion
+    bit_offset: 4
+    bit_size: 1
+  - name: RSTCAL
+    description: Reset calibration
+    bit_offset: 29
+    bit_size: 1
+  - name: ADCAL_START
+    description: Calibration start
+    bit_offset: 30
+    bit_size: 1
+  - name: ADCAL
+    description: Calibration status
+    bit_offset: 31
+    bit_size: 1
+fieldset/DR:
+  description: ADC regular data register
+  fields:
+  - name: DATA
+    description: Regular data converted
+    bit_offset: 0
+    bit_size: 16
+fieldset/IER:
+  description: ADC interrupt enable register
+  fields:
+  - name: EOSMPIE
+    description: End of sampling interrupt enable
+    bit_offset: 1
+    bit_size: 1
+  - name: EOCIE
+    description: End of conversion interrupt enable
+    bit_offset: 2
+    bit_size: 1
+  - name: EOSEQIE
+    description: End of sequence interrupt enable
+    bit_offset: 3
+    bit_size: 1
+  - name: OVRIE
+    description: Overrun interrupt enable
+    bit_offset: 4
+    bit_size: 1
+  - name: AWDIE
+    description: Analog watchdog interrupt enable
+    bit_offset: 7
+    bit_size: 1
+  - name: EOHIE
+    description: End of hardware conversion interrupt enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/ISR:
+  description: ADC interrupt and status register
+  fields:
+  - name: EOSMP
+    description: End of sampling flag
+    bit_offset: 1
+    bit_size: 1
+  - name: EOC
+    description: End of conversion flag
+    bit_offset: 2
+    bit_size: 1
+  - name: EOSEQ
+    description: End of sequence flag
+    bit_offset: 3
+    bit_size: 1
+  - name: OVR
+    description: Overrun flag
+    bit_offset: 4
+    bit_size: 1
+  - name: AWD
+    description: Analog watchdog flag
+    bit_offset: 7
+    bit_size: 1
+  - name: EOH
+    description: End of hardware conversion flag
+    bit_offset: 8
+    bit_size: 1
+fieldset/SMPR:
+  description: ADC sampling time register
+  fields:
+  - name: SMP
+    description: Sampling time selection
+    bit_offset: 0
+    bit_size: 3
+fieldset/SQR1:
+  description: ADC regular sequence register 1
+  fields:
+  - name: L
+    description: Regular channel sequence length
+    bit_offset: 0
+    bit_size: 4
+  - name: SQ1
+    description: 1st conversion in regular sequence
+    bit_offset: 6
+    bit_size: 4
+  - name: SQ2
+    description: 2nd conversion in regular sequence
+    bit_offset: 12
+    bit_size: 4
+  - name: SQ3
+    description: 3rd conversion in regular sequence
+    bit_offset: 18
+    bit_size: 4
+  - name: SQ4
+    description: 4th conversion in regular sequence
+    bit_offset: 24
+    bit_size: 4
+fieldset/SQR2:
+  description: ADC regular sequence register 2
+  fields:
+  - name: SQ5
+    description: 5th conversion in regular sequence
+    bit_offset: 0
+    bit_size: 4
+  - name: SQ6
+    description: 6th conversion in regular sequence
+    bit_offset: 6
+    bit_size: 4
+  - name: SQ7
+    description: 7th conversion in regular sequence
+    bit_offset: 12
+    bit_size: 4
+  - name: SQ8
+    description: 8th conversion in regular sequence
+    bit_offset: 18
+    bit_size: 4
+  - name: SQ9
+    description: 9th conversion in regular sequence
+    bit_offset: 24
+    bit_size: 4
+fieldset/SQR3:
+  description: ADC regular sequence register 3
+  fields:
+  - name: SQ10
+    description: 10th conversion in regular sequence
+    bit_offset: 0
+    bit_size: 4
+  - name: SQ11
+    description: 11th conversion in regular sequence
+    bit_offset: 6
+    bit_size: 4
+fieldset/TR:
+  description: ADC analog watchdog 1 threshold register
+  fields:
+  - name: LT1
+    description: Analog watchdog 1 lower threshold
+    bit_offset: 0
+    bit_size: 12
+  - name: HT1
+    description: Analog watchdog 1 higher threshold
+    bit_offset: 16
+    bit_size: 12

--- a/data/registers/configbytes_ms32c001b.yaml
+++ b/data/registers/configbytes_ms32c001b.yaml
@@ -1,0 +1,99 @@
+block/CONFIGBYTES:
+  description: Flash option bytes (MS32C001B, mapped at 0x1FFF0040)
+  items:
+  - name: OPTR
+    description: User option bytes and complements (loaded into FLASH_OPTR at reset)
+    byte_offset: 0
+    access: Read
+    fieldset: OPTR
+  - name: SDKR
+    description: SDK area address option bytes and complements (loaded into FLASH_SDKR at reset)
+    byte_offset: 4
+    access: Read
+    fieldset: SDKR
+  - name: WRPR
+    description: WRP address option bytes and complements (loaded into FLASH_WRPR at reset)
+    byte_offset: 12
+    access: Read
+    fieldset: WRPR
+fieldset/OPTR:
+  description: User option bytes and complements
+  fields:
+  - name: RDP
+    description: "Read protection level (0xAA: level 0, no protection; otherwise: level 1, protection active)"
+    bit_offset: 0
+    bit_size: 8
+  - name: BOR_EN
+    description: "BOR enable (0: disabled; 1: enabled, BOR_LEV active)"
+    bit_offset: 8
+    bit_size: 1
+  - name: BOR_LEV
+    description: "BOR threshold level (000: 2.2V/2.1V ... 111: 3.6V/3.5V)"
+    bit_offset: 9
+    bit_size: 3
+  - name: IWDG_SW
+    description: "IWDG mode (0: hardware watchdog; 1: software watchdog)"
+    bit_offset: 12
+    bit_size: 1
+  - name: NRST_MODE
+    description: "NRST pin mode (0: reset input only; 1: GPIO function)"
+    bit_offset: 14
+    bit_size: 1
+  - name: IWDG_STOP
+    description: "IWDG behavior in Stop mode (0: freeze; 1: keep running)"
+    bit_offset: 15
+    bit_size: 1
+  - name: NRDP
+    description: Complemented read protection level
+    bit_offset: 16
+    bit_size: 8
+  - name: NBOR_EN
+    description: Complemented BOR enable
+    bit_offset: 24
+    bit_size: 1
+  - name: NBOR_LEV
+    description: Complemented BOR threshold level
+    bit_offset: 25
+    bit_size: 3
+  - name: NIWDG_SW
+    description: Complemented IWDG mode
+    bit_offset: 28
+    bit_size: 1
+  - name: NNRST_MODE
+    description: Complemented NRST pin mode
+    bit_offset: 30
+    bit_size: 1
+  - name: NIWDG_STOP
+    description: Complemented IWDG Stop mode behavior
+    bit_offset: 31
+    bit_size: 1
+fieldset/SDKR:
+  description: SDK area address option bytes and complements
+  fields:
+  - name: SDK_STRT
+    description: SDK area start address (step = 1 KB)
+    bit_offset: 0
+    bit_size: 4
+  - name: SDK_END
+    description: SDK area end address (step = 1 KB)
+    bit_offset: 8
+    bit_size: 4
+  - name: NSDK_STRT
+    description: Complemented SDK area start address
+    bit_offset: 16
+    bit_size: 4
+  - name: NSDK_END
+    description: Complemented SDK area end address
+    bit_offset: 24
+    bit_size: 4
+fieldset/WRPR:
+  description: WRP address option bytes and complements
+  fields:
+  - name: WRP
+    description: "Write protection bits (0: sector[y] protected; 1: unprotected; y = 0..15)"
+    bit_offset: 0
+    bit_size: 16
+  - name: NWRP
+    description: Complemented write protection bits
+    bit_offset: 16
+    bit_size: 16

--- a/data/registers/exti_v1b.yaml
+++ b/data/registers/exti_v1b.yaml
@@ -1,0 +1,76 @@
+block/EXTI:
+  description: External interrupt/event controller (MS32C001B, per RM chapter 9)
+  items:
+  - name: RTSR
+    description: Rising trigger selection register (configurable lines)
+    byte_offset: 0
+    fieldset: LINES_CFG
+  - name: FTSR
+    description: Falling trigger selection register (configurable lines)
+    byte_offset: 4
+    fieldset: LINES_CFG
+  - name: SWIER
+    description: Software interrupt event register (configurable lines)
+    byte_offset: 8
+    fieldset: LINES_CFG
+  - name: PR
+    description: EXTI pending register (configurable lines, write 1 to clear)
+    byte_offset: 12
+    fieldset: LINES_CFG
+  - name: EXTICR
+    description: EXTI external interrupt selection register
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 96
+    fieldset: EXTICR
+  - name: IMR
+    description: EXTI interrupt mask register
+    byte_offset: 128
+    fieldset: LINES_MSK
+  - name: EMR
+    description: EXTI event mask register
+    byte_offset: 132
+    fieldset: LINES_MSK
+fieldset/LINES_CFG:
+  description: Configurable EXTI lines register (lines 0-7 GPIO + line 16 PVD), 1 bit per line
+  fields:
+  - name: LINE
+    description: EXTI line
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+  - name: LINE16
+    description: EXTI line 16 (PVD)
+    bit_offset: 16
+    bit_size: 1
+fieldset/LINES_MSK:
+  description: EXTI mask register (lines 0-7 GPIO, line 16 PVD, line 29 LPTIM direct), 1 bit per line
+  fields:
+  - name: LINE
+    description: EXTI line
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+  - name: LINE16
+    description: EXTI line 16 (PVD)
+    bit_offset: 16
+    bit_size: 1
+  - name: LINE29
+    description: EXTI line 29 (LPTIM, direct type)
+    bit_offset: 29
+    bit_size: 1
+fieldset/EXTICR:
+  description: External interrupt configuration register (one 2-bit port selector per line)
+  fields:
+  - name: EXTI
+    description: EXTI configuration bits
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 4
+      stride: 8

--- a/data/registers/flash_ms32c001b.yaml
+++ b/data/registers/flash_ms32c001b.yaml
@@ -1,0 +1,255 @@
+block/FLASH:
+  description: Flash (MS32C001B)
+  items:
+  - name: KEYR
+    description: Flash key register
+    byte_offset: 8
+    fieldset: KEYR
+  - name: OPTKEYR
+    description: Option byte key register
+    byte_offset: 12
+    fieldset: OPTKEYR
+  - name: SR
+    description: Status register
+    byte_offset: 16
+    fieldset: SR
+  - name: CR
+    description: Flash control register
+    byte_offset: 20
+    fieldset: CR
+  - name: OPTR
+    description: Flash option register
+    byte_offset: 32
+    fieldset: OPTR
+  - name: SDKR
+    description: Flash SDK address register
+    byte_offset: 36
+    fieldset: SDKR
+  - name: WRPR
+    description: Flash WRP address register
+    byte_offset: 44
+    fieldset: WRPR
+  - name: STCR
+    description: Flash sleep time config register
+    byte_offset: 144
+    fieldset: STCR
+  - name: TS0
+    description: Flash TS0 register
+    byte_offset: 256
+    fieldset: TS0
+  - name: TS1
+    description: Flash TS1 register
+    byte_offset: 260
+    fieldset: TS1
+  - name: TS2P
+    description: Flash TS2P register
+    byte_offset: 264
+    fieldset: TS2P
+  - name: TPS3
+    description: Flash TPS3 register
+    byte_offset: 268
+    fieldset: TPS3
+  - name: TS3
+    description: Flash TS3 register
+    byte_offset: 272
+    fieldset: TS3
+  - name: ERTPE
+    description: Flash ERTPE register
+    byte_offset: 276
+    fieldset: ERTPE
+  - name: PRGTPE
+    description: Flash PRGTPE register
+    byte_offset: 284
+    fieldset: PRGTPE
+  - name: PRETPE
+    description: Flash PRETPE register
+    byte_offset: 288
+    fieldset: PRETPE
+fieldset/CR:
+  description: Flash control register
+  fields:
+  - name: PG
+    description: Page Program
+    bit_offset: 0
+    bit_size: 1
+  - name: PER
+    description: Page Erase
+    bit_offset: 1
+    bit_size: 1
+  - name: MER
+    description: Mass Erase
+    bit_offset: 2
+    bit_size: 1
+  - name: SER
+    description: Sector Erase
+    bit_offset: 11
+    bit_size: 1
+  - name: OPTSTRT
+    description: Option bytes Programming Start
+    bit_offset: 17
+    bit_size: 1
+  - name: PGSTRT
+    description: Programming Start
+    bit_offset: 19
+    bit_size: 1
+  - name: EOPIE
+    description: End of operation interrupt enable
+    bit_offset: 24
+    bit_size: 1
+  - name: ERRIE
+    description: Error interrupt enable
+    bit_offset: 25
+    bit_size: 1
+  - name: OBL_LAUNCH
+    description: Force the option bytes loading
+    bit_offset: 27
+    bit_size: 1
+  - name: OPTLOCK
+    description: Option Lock
+    bit_offset: 30
+    bit_size: 1
+  - name: LOCK
+    description: Lock
+    bit_offset: 31
+    bit_size: 1
+fieldset/ERTPE:
+  description: Flash ERTPE register
+  fields:
+  - name: ERTPE
+    description: ERTPE value
+    bit_offset: 0
+    bit_size: 16
+fieldset/KEYR:
+  description: Flash key register
+  fields:
+  - name: KEY
+    description: Flash CR key
+    bit_offset: 0
+    bit_size: 32
+fieldset/OPTKEYR:
+  description: Option byte key register
+  fields:
+  - name: OPTKEY
+    description: Flash Option key
+    bit_offset: 0
+    bit_size: 32
+fieldset/OPTR:
+  description: Flash option register
+  fields:
+  - name: RDP
+    description: Read Protection
+    bit_offset: 0
+    bit_size: 8
+  - name: BOR_EN
+    description: BOR enable
+    bit_offset: 8
+    bit_size: 1
+  - name: BOR_LEV
+    description: BOR level
+    bit_offset: 9
+    bit_size: 3
+  - name: IWDG_SW
+    description: IWDG software enable
+    bit_offset: 12
+    bit_size: 1
+  - name: NRST_MODE
+    description: NRST pin mode
+    bit_offset: 14
+    bit_size: 1
+  - name: IWDG_STOP
+    description: IWDG stop in debug
+    bit_offset: 15
+    bit_size: 1
+fieldset/PRETPE:
+  description: Flash PRETPE register
+  fields:
+  - name: PRETPE
+    description: PRETPE value
+    bit_offset: 0
+    bit_size: 14
+fieldset/PRGTPE:
+  description: Flash PRGTPE register
+  fields:
+  - name: PRGTPE
+    description: PRGTPE value
+    bit_offset: 0
+    bit_size: 16
+fieldset/SDKR:
+  description: Flash SDK address register
+  fields:
+  - name: SDK_STRT
+    description: SDK area start address
+    bit_offset: 0
+    bit_size: 4
+  - name: SDK_END
+    description: SDK area end address
+    bit_offset: 8
+    bit_size: 4
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: EOP
+    description: End of operation
+    bit_offset: 0
+    bit_size: 1
+  - name: WRPERR
+    description: Write protection error
+    bit_offset: 4
+    bit_size: 1
+  - name: OPTVERR
+    description: Option and trimming bits loading validity error
+    bit_offset: 15
+    bit_size: 1
+  - name: BSY
+    description: Busy
+    bit_offset: 16
+    bit_size: 1
+fieldset/STCR:
+  description: Flash sleep time config register
+  fields:
+  - name: SLEEP_EN
+    description: Sleep enable
+    bit_offset: 0
+    bit_size: 1
+fieldset/TPS3:
+  description: Flash TPS3 register
+  fields:
+  - name: TPS3
+    description: TPS3 value
+    bit_offset: 0
+    bit_size: 10
+fieldset/TS0:
+  description: Flash TS0 register
+  fields:
+  - name: TS0
+    description: TS0 value
+    bit_offset: 0
+    bit_size: 8
+fieldset/TS1:
+  description: Flash TS1 register
+  fields:
+  - name: TS1
+    description: TS1 value
+    bit_offset: 0
+    bit_size: 8
+fieldset/TS2P:
+  description: Flash TS2P register
+  fields:
+  - name: TS2P
+    description: TS2P value
+    bit_offset: 0
+    bit_size: 8
+fieldset/TS3:
+  description: Flash TS3 register
+  fields:
+  - name: TS3
+    description: TS3 value
+    bit_offset: 0
+    bit_size: 8
+fieldset/WRPR:
+  description: Flash WRP address register
+  fields:
+  - name: WRP
+    description: Write protection address
+    bit_offset: 0
+    bit_size: 16

--- a/data/registers/gpio_v1b.yaml
+++ b/data/registers/gpio_v1b.yaml
@@ -1,0 +1,235 @@
+block/GPIO:
+  description: General-purpose I/Os (8 IO per port on MS32C001B, per RM chapter 7).
+  items:
+  - name: MODER
+    description: GPIO port mode register.
+    byte_offset: 0
+    fieldset: MODER
+  - name: OTYPER
+    description: GPIO port output type register.
+    byte_offset: 4
+    fieldset: OTYPER
+  - name: OSPEEDR
+    description: GPIO port output speed register.
+    byte_offset: 8
+    fieldset: OSPEEDR
+  - name: PUPDR
+    description: GPIO port pull-up/pull-down register.
+    byte_offset: 12
+    fieldset: PUPDR
+  - name: IDR
+    description: GPIO port input data register.
+    byte_offset: 16
+    access: Read
+    fieldset: IDR
+  - name: ODR
+    description: GPIO port output data register.
+    byte_offset: 20
+    fieldset: ODR
+  - name: BSRR
+    description: GPIO port bit set/reset register.
+    byte_offset: 24
+    access: Write
+    fieldset: BSRR
+  - name: LCKR
+    description: GPIO port configuration lock register.
+    byte_offset: 28
+    fieldset: LCKR
+  - name: AFR
+    description: GPIO alternate function register (single register, pins 0-7).
+    byte_offset: 32
+    fieldset: AFR
+  - name: BRR
+    description: GPIO port bit reset register.
+    byte_offset: 40
+    access: Write
+    fieldset: BRR
+fieldset/AFR:
+  description: GPIO alternate function register, pins 0-7 of the port.
+  fields:
+  - name: AFR
+    description: Alternate function selection (AF0-AF15)
+    bit_offset: 0
+    bit_size: 4
+    array:
+      len: 8
+      stride: 4
+fieldset/BSRR:
+  description: GPIO port bit set/reset register.
+  fields:
+  - name: BS
+    description: Port x set bit y (y= 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+  - name: BR
+    description: Port x reset bit y (y= 0..7, at bits 16-23)
+    bit_offset: 16
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+fieldset/IDR:
+  description: GPIO port input data register.
+  fields:
+  - name: IDR
+    description: Port input data (y = 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+    enum: IDR
+fieldset/LCKR:
+  description: GPIO port configuration lock register.
+  fields:
+  - name: LCK
+    description: Port configuration locked (y = 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+  - name: LCKK
+    description: "Port lock key bit (write sequence: 1->0->1->read 0->read 1)"
+    bit_offset: 16
+    bit_size: 1
+fieldset/MODER:
+  description: GPIO port mode register.
+  fields:
+  - name: MODER
+    description: Port x configuration bits (y = 0..7)
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 8
+      stride: 2
+    enum: MODER
+fieldset/ODR:
+  description: GPIO port output data register.
+  fields:
+  - name: ODR
+    description: Port output data (y = 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+    enum: ODR
+fieldset/OSPEEDR:
+  description: GPIO port output speed register.
+  fields:
+  - name: OSPEEDR
+    description: Port x configuration bits (y = 0..7)
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 8
+      stride: 2
+    enum: OSPEEDR
+fieldset/OTYPER:
+  description: GPIO port output type register.
+  fields:
+  - name: OT
+    description: Port x configuration bits (y = 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+    enum: OT
+fieldset/PUPDR:
+  description: GPIO port pull-up/pull-down register.
+  fields:
+  - name: PUPDR
+    description: Port x configuration bits (y = 0..7)
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 8
+      stride: 2
+    enum: PUPDR
+fieldset/BRR:
+  description: GPIO port bit reset register.
+  fields:
+  - name: BR
+    description: Reset bit (y = 0..7)
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 1
+enum/IDR:
+  bit_size: 1
+  variants:
+  - name: Low
+    description: Input is logic low
+    value: 0
+  - name: High
+    description: Input is logic high
+    value: 1
+enum/MODER:
+  bit_size: 2
+  variants:
+  - name: Input
+    description: Input mode
+    value: 0
+  - name: Output
+    description: General purpose output mode
+    value: 1
+  - name: Alternate
+    description: Alternate function mode
+    value: 2
+  - name: Analog
+    description: Analog mode (reset state)
+    value: 3
+enum/ODR:
+  bit_size: 1
+  variants:
+  - name: Low
+    description: Set output to logic low
+    value: 0
+  - name: High
+    description: Set output to logic high
+    value: 1
+enum/OSPEEDR:
+  bit_size: 2
+  variants:
+  - name: LowSpeed
+    description: Low speed
+    value: 0
+  - name: HighSpeed
+    description: High speed
+    value: 1
+  - name: HighSpeed2
+    description: High speed (alternate encoding)
+    value: 2
+  - name: VeryHighSpeed
+    description: Very high speed
+    value: 3
+enum/OT:
+  bit_size: 1
+  variants:
+  - name: PushPull
+    description: Output push-pull (reset state)
+    value: 0
+  - name: OpenDrain
+    description: Output open-drain
+    value: 1
+enum/PUPDR:
+  bit_size: 2
+  variants:
+  - name: Floating
+    description: No pull-up, pull-down
+    value: 0
+  - name: PullUp
+    description: Pull-up
+    value: 1
+  - name: PullDown
+    description: Pull-down
+    value: 2
+  - name: PullUpPullDown
+    description: Pull-up and pull-down
+    value: 3

--- a/data/registers/pwm_v1.yaml
+++ b/data/registers/pwm_v1.yaml
@@ -1,0 +1,180 @@
+block/PWM:
+  description: LED-driving PWM timer (MS32C001B)
+  items:
+  - name: CR1
+    description: PWM control register 1
+    byte_offset: 0
+    fieldset: CR1
+  - name: DIER
+    description: PWM DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER
+  - name: SR
+    description: PWM status register
+    byte_offset: 16
+    fieldset: SR
+  - name: EGR
+    description: PWM event generation register
+    byte_offset: 20
+    fieldset: EGR
+  - name: CMR
+    description: PWM compare mode register
+    byte_offset: 24
+    fieldset: CMR
+  - name: CER
+    description: PWM capture/compare enable register
+    byte_offset: 32
+    fieldset: CER
+  - name: CNT
+    description: PWM counter
+    byte_offset: 36
+    fieldset: CNT
+  - name: PSC
+    description: PWM prescaler
+    byte_offset: 40
+    fieldset: PSC
+  - name: ARR
+    description: PWM auto-reload register
+    byte_offset: 44
+    fieldset: ARR
+  - name: CCR1
+    description: PWM capture/compare register 1
+    byte_offset: 52
+    fieldset: CCR1
+  - name: LED1_DATA
+    description: PWM LED1 data register
+    byte_offset: 80
+    fieldset: LED1_DATA
+fieldset/ARR:
+  description: PWM auto-reload register
+  fields:
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 0
+    bit_size: 10
+fieldset/CCR1:
+  description: PWM capture/compare register 1
+  fields:
+  - name: CCR1
+    description: Capture/compare 1 value
+    bit_offset: 0
+    bit_size: 10
+fieldset/CER:
+  description: PWM capture/compare enable register
+  fields:
+  - name: C1E
+    description: Capture/compare 1 output enable
+    bit_offset: 0
+    bit_size: 1
+  - name: C1P
+    description: Capture/compare 1 output polarity
+    bit_offset: 1
+    bit_size: 1
+fieldset/CMR:
+  description: PWM compare mode register
+  fields:
+  - name: OC1M
+    description: Output compare 1 mode
+    bit_offset: 0
+    bit_size: 2
+  - name: OC1PE
+    description: Output compare 1 preload enable
+    bit_offset: 8
+    bit_size: 1
+fieldset/CNT:
+  description: PWM counter
+  fields:
+  - name: CNT
+    description: Counter value
+    bit_offset: 0
+    bit_size: 10
+fieldset/CR1:
+  description: PWM control register 1
+  fields:
+  - name: CEN
+    description: Counter enable
+    bit_offset: 0
+    bit_size: 1
+  - name: UDIS
+    description: Update disable
+    bit_offset: 1
+    bit_size: 1
+  - name: URS
+    description: Update request source
+    bit_offset: 2
+    bit_size: 1
+  - name: DIR
+    description: Direction
+    bit_offset: 4
+    bit_size: 1
+  - name: CMS
+    description: Center-aligned mode selection
+    bit_offset: 5
+    bit_size: 2
+  - name: ARPE
+    description: Auto-reload preload enable
+    bit_offset: 7
+    bit_size: 1
+  - name: LEDEN
+    description: LED output enable
+    bit_offset: 16
+    bit_size: 1
+  - name: LEDCEN
+    description: LED clock enable
+    bit_offset: 17
+    bit_size: 1
+  - name: LEDWORD
+    description: LED word length
+    bit_offset: 18
+    bit_size: 2
+fieldset/DIER:
+  description: PWM DMA/Interrupt enable register
+  fields:
+  - name: UIE
+    description: Update interrupt enable
+    bit_offset: 0
+    bit_size: 1
+  - name: OC1IE
+    description: Capture/compare 1 interrupt enable
+    bit_offset: 1
+    bit_size: 1
+  - name: LED1_ENDIE
+    description: LED1 end interrupt enable
+    bit_offset: 16
+    bit_size: 1
+fieldset/EGR:
+  description: PWM event generation register
+  fields:
+  - name: UG
+    description: Update generation
+    bit_offset: 0
+    bit_size: 1
+fieldset/LED1_DATA:
+  description: PWM LED1 data register
+  fields:
+  - name: LED1_DATA
+    description: LED1 data
+    bit_offset: 0
+    bit_size: 24
+fieldset/PSC:
+  description: PWM prescaler
+  fields:
+  - name: PSC
+    description: Prescaler value
+    bit_offset: 0
+    bit_size: 8
+fieldset/SR:
+  description: PWM status register
+  fields:
+  - name: UIF
+    description: Update interrupt flag
+    bit_offset: 0
+    bit_size: 1
+  - name: OC1IF
+    description: Capture/compare 1 interrupt flag
+    bit_offset: 1
+    bit_size: 1
+  - name: LED1_ENDIF
+    description: LED1 end interrupt flag
+    bit_offset: 16
+    bit_size: 1

--- a/data/registers/rcc_ms32c001b.yaml
+++ b/data/registers/rcc_ms32c001b.yaml
@@ -1,0 +1,410 @@
+block/RCC:
+  description: Reset and clock control (MS32C001B)
+  items:
+  - name: CR
+    description: Clock control register
+    byte_offset: 0
+    fieldset: CR
+  - name: ICSCR
+    description: Internal clock sources calibration register
+    byte_offset: 4
+    fieldset: ICSCR
+  - name: CFGR
+    description: Clock configuration register
+    byte_offset: 8
+    fieldset: CFGR
+  - name: ECSCR
+    description: External clock source control register
+    byte_offset: 16
+    fieldset: ECSCR
+  - name: CIER
+    description: Clock interrupt enable register
+    byte_offset: 24
+    fieldset: CIER
+  - name: CIFR
+    description: Clock interrupt flag register
+    byte_offset: 28
+    fieldset: CIFR
+  - name: CICR
+    description: Clock interrupt clear register
+    byte_offset: 32
+    fieldset: CICR
+  - name: IOPRSTR
+    description: GPIO reset register
+    byte_offset: 36
+    fieldset: IOPRSTR
+  - name: APBRSTR1
+    description: APB peripheral reset register 1
+    byte_offset: 44
+    fieldset: APBRSTR1
+  - name: APBRSTR2
+    description: APB peripheral reset register 2
+    byte_offset: 48
+    fieldset: APBRSTR2
+  - name: IOPENR
+    description: GPIO clock enable register
+    byte_offset: 52
+    fieldset: IOPENR
+  - name: AHBENR
+    description: AHB peripheral clock enable register
+    byte_offset: 56
+    fieldset: AHBENR
+  - name: APBENR1
+    description: APB peripheral clock enable register 1
+    byte_offset: 60
+    fieldset: APBENR1
+  - name: APBENR2
+    description: APB peripheral clock enable register 2
+    byte_offset: 64
+    fieldset: APBENR2
+  - name: CCIPR
+    description: Peripherals independent clock configuration register
+    byte_offset: 84
+    fieldset: CCIPR
+  - name: BDCR
+    description: RTC domain control register
+    byte_offset: 92
+    fieldset: BDCR
+  - name: CSR
+    description: Control/status register
+    byte_offset: 96
+    fieldset: CSR
+fieldset/AHBENR:
+  description: AHB peripheral clock enable register
+  fields:
+  - name: FLASHEN
+    description: FLASH clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: SRAMEN
+    description: SRAM clock enable
+    bit_offset: 9
+    bit_size: 1
+fieldset/APBENR1:
+  description: APB peripheral clock enable register 1
+  fields:
+  - name: UART1EN
+    description: UART1 clock enable
+    bit_offset: 18
+    bit_size: 1
+  - name: DBGEN
+    description: MCU Debug module clock enable
+    bit_offset: 27
+    bit_size: 1
+  - name: PWREN
+    description: Power interface module clock enable
+    bit_offset: 28
+    bit_size: 1
+  - name: LPTIMEN
+    description: LPTIM clock enable
+    bit_offset: 31
+    bit_size: 1
+fieldset/APBENR2:
+  description: APB peripheral clock enable register 2
+  fields:
+  - name: SYSCFGEN
+    description: SYSCFG module clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: PWMEN
+    description: PWM module clock enable
+    bit_offset: 9
+    bit_size: 1
+  - name: TIM1EN
+    description: TIM1 module clock enable
+    bit_offset: 11
+    bit_size: 1
+  - name: TIM14EN
+    description: TIM14 module clock enable
+    bit_offset: 15
+    bit_size: 1
+  - name: ADCEN
+    description: ADC clock enable
+    bit_offset: 20
+    bit_size: 1
+  - name: VREFBUFEN
+    description: VREFBUF clock enable
+    bit_offset: 26
+    bit_size: 1
+fieldset/APBRSTR1:
+  description: APB peripheral reset register 1
+  fields:
+  - name: UART1RST
+    description: UART1 module reset
+    bit_offset: 18
+    bit_size: 1
+  - name: DBGRST
+    description: MCU Debug module reset
+    bit_offset: 27
+    bit_size: 1
+  - name: PWRRST
+    description: Power interface module reset
+    bit_offset: 28
+    bit_size: 1
+  - name: LPTIMRST
+    description: LPTIM module reset
+    bit_offset: 31
+    bit_size: 1
+fieldset/APBRSTR2:
+  description: APB peripheral reset register 2
+  fields:
+  - name: SYSCFGRST
+    description: SYSCFG module reset
+    bit_offset: 0
+    bit_size: 1
+  - name: PWMRST
+    description: PWM module reset
+    bit_offset: 9
+    bit_size: 1
+  - name: TIM1RST
+    description: TIM1 module reset
+    bit_offset: 11
+    bit_size: 1
+  - name: TIM14RST
+    description: TIM14 module reset
+    bit_offset: 15
+    bit_size: 1
+  - name: ADCRST
+    description: ADC reset
+    bit_offset: 20
+    bit_size: 1
+  - name: VREFBUFRST
+    description: VREFBUF reset
+    bit_offset: 26
+    bit_size: 1
+fieldset/BDCR:
+  description: RTC domain control register
+  fields:
+  - name: LSEON
+    description: LSE OSC enabled
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDY
+    description: LSE OSC ready
+    bit_offset: 1
+    bit_size: 1
+  - name: LSEBYP
+    description: LSE OSC bypass
+    bit_offset: 2
+    bit_size: 1
+  - name: LSECSSON
+    description: LSE CSS enable
+    bit_offset: 5
+    bit_size: 1
+  - name: LSECSSD
+    description: LSE CSS detection failed
+    bit_offset: 6
+    bit_size: 1
+  - name: LSCSEL
+    description: Low-speed clock selection
+    bit_offset: 25
+    bit_size: 1
+fieldset/CCIPR:
+  description: Peripherals independent clock configuration register
+  fields:
+  - name: PVDSEL
+    description: PVD module clock source selection
+    bit_offset: 7
+    bit_size: 1
+  - name: LPTIM1SEL
+    description: LPTIM1 clock source selection
+    bit_offset: 18
+    bit_size: 2
+fieldset/CFGR:
+  description: Clock configuration register
+  fields:
+  - name: SW
+    description: System clock source selection
+    bit_offset: 0
+    bit_size: 3
+  - name: SWS
+    description: System clock switch status
+    bit_offset: 3
+    bit_size: 3
+  - name: HPRE
+    description: AHB clock HCLK division factor
+    bit_offset: 8
+    bit_size: 4
+  - name: PPRE
+    description: APB clock division factor
+    bit_offset: 12
+    bit_size: 3
+  - name: MCOSEL
+    description: MCO output clock selection
+    bit_offset: 24
+    bit_size: 3
+  - name: MCOPRE
+    description: MCO output clock divider factor
+    bit_offset: 28
+    bit_size: 3
+fieldset/CICR:
+  description: Clock interrupt clear register
+  fields:
+  - name: LSIRDYC
+    description: LSI ready interrupt flag clear
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYC
+    description: LSE ready interrupt flag clear
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYC
+    description: HSI ready interrupt flag clear
+    bit_offset: 3
+    bit_size: 1
+  - name: LSECSSC
+    description: LSE CSS interrupt flag clear
+    bit_offset: 9
+    bit_size: 1
+fieldset/CIER:
+  description: Clock interrupt enable register
+  fields:
+  - name: LSIRDYIE
+    description: LSI clock ready interrupt enable
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYIE
+    description: LSE clock ready interrupt enable
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYIE
+    description: HSI clock ready interrupt enable
+    bit_offset: 3
+    bit_size: 1
+fieldset/CIFR:
+  description: Clock interrupt flag register
+  fields:
+  - name: LSIRDYF
+    description: LSI clock ready interrupt flag
+    bit_offset: 0
+    bit_size: 1
+  - name: LSERDYF
+    description: LSE clock ready interrupt flag
+    bit_offset: 1
+    bit_size: 1
+  - name: HSIRDYF
+    description: HSI clock ready interrupt flag
+    bit_offset: 3
+    bit_size: 1
+  - name: LSECSSF
+    description: LSE CSS interrupt flag
+    bit_offset: 9
+    bit_size: 1
+fieldset/CR:
+  description: Clock control register
+  fields:
+  - name: HSION
+    description: HSI clock enable
+    bit_offset: 8
+    bit_size: 1
+  - name: HSIRDY
+    description: HSI clock ready
+    bit_offset: 10
+    bit_size: 1
+  - name: HSIDIV
+    description: HSI divider for HSISYS clock
+    bit_offset: 11
+    bit_size: 3
+  - name: HSEON
+    description: HSE clock enable
+    bit_offset: 18
+    bit_size: 1
+fieldset/CSR:
+  description: Control/status register
+  fields:
+  - name: LSION
+    description: LSI OSC enabled
+    bit_offset: 0
+    bit_size: 1
+  - name: LSIRDY
+    description: LSI OSC ready
+    bit_offset: 1
+    bit_size: 1
+  - name: PINRST_FLTDIS
+    description: NRST filtering disable
+    bit_offset: 8
+    bit_size: 1
+  - name: RMVF
+    description: Clear reset flag
+    bit_offset: 23
+    bit_size: 1
+  - name: OBLRSTF
+    description: Option byte loader reset flag
+    bit_offset: 25
+    bit_size: 1
+  - name: PINRSTF
+    description: External NRST pin reset flag
+    bit_offset: 26
+    bit_size: 1
+  - name: PORRSTF
+    description: POR reset flag
+    bit_offset: 27
+    bit_size: 1
+  - name: SFTRSTF
+    description: Soft reset flag
+    bit_offset: 28
+    bit_size: 1
+  - name: IWDGRSTF
+    description: IWDG reset flag
+    bit_offset: 29
+    bit_size: 1
+fieldset/ECSCR:
+  description: External clock source control register
+  fields:
+  - name: LSE_DRIVER
+    description: LSE drive capability setting
+    bit_offset: 16
+    bit_size: 2
+  - name: LSE_STARTUP
+    description: LSE crystal oscillator stabilization time selection
+    bit_offset: 20
+    bit_size: 2
+fieldset/ICSCR:
+  description: Internal clock sources calibration register
+  fields:
+  - name: HSI_ABS_TRIMCR
+    description: HSI clock frequency calibration value
+    bit_offset: 0
+    bit_size: 12
+  - name: HSI_TC_TRIMCR
+    description: HSI temperature compensation trimming value
+    bit_offset: 12
+    bit_size: 4
+  - name: HSI_FS
+    description: HSI frequency selection
+    bit_offset: 16
+    bit_size: 1
+  - name: LSI_TRIM
+    description: LSI trimming value
+    bit_offset: 19
+    bit_size: 9
+fieldset/IOPENR:
+  description: GPIO clock enable register
+  fields:
+  - name: GPIOAEN
+    description: I/O PortA clock enable
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBEN
+    description: I/O PortB clock enable
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCEN
+    description: I/O PortC clock enable
+    bit_offset: 2
+    bit_size: 1
+fieldset/IOPRSTR:
+  description: GPIO reset register
+  fields:
+  - name: GPIOARST
+    description: I/O PortA reset
+    bit_offset: 0
+    bit_size: 1
+  - name: GPIOBRST
+    description: I/O PortB reset
+    bit_offset: 1
+    bit_size: 1
+  - name: GPIOCRST
+    description: I/O PortC reset
+    bit_offset: 2
+    bit_size: 1

--- a/data/registers/timer_v1b.yaml
+++ b/data/registers/timer_v1b.yaml
@@ -1,0 +1,1417 @@
+block/TIM_1CH:
+  extends: TIM_CORE
+  description: 1-channel timers
+  items:
+  - name: CR1
+    byte_offset: 0
+    fieldset: CR1_1CH
+    description: control register 1
+  - name: DIER
+    byte_offset: 12
+    fieldset: DIER_1CH
+    description: DMA/Interrupt enable register
+  - name: SR
+    byte_offset: 16
+    fieldset: SR_1CH
+    description: status register
+  - name: EGR
+    byte_offset: 20
+    bit_size: 16
+    access: Write
+    fieldset: EGR_1CH
+    description: event generation register
+  - name: CCMR_Input
+    array:
+      len: 1
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Input_1CH
+    description: capture/compare mode register 1 (input mode)
+  - name: CCMR_Output
+    array:
+      len: 1
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_1CH
+    description: capture/compare mode register 1 (output mode)
+  - name: CCER
+    byte_offset: 32
+    fieldset: CCER_1CH
+    description: capture/compare enable register
+  - name: CCR
+    array:
+      len: 1
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_1CH
+    description: capture/compare register x (x=1)
+  - name: TISEL
+    byte_offset: 92
+    fieldset: TISEL_1CH
+    description: input selection register
+block/TIM_ADV:
+  extends: TIM_CORE
+  description: Advanced Control timers
+  items:
+  - name: CR1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_GP16
+    description: control register 1
+  - name: CR2
+    byte_offset: 4
+    fieldset: CR2_ADV
+    description: control register 2
+  - name: SMCR
+    byte_offset: 8
+    fieldset: SMCR_GP16
+    description: slave mode control register
+  - name: DIER
+    byte_offset: 12
+    fieldset: DIER_ADV
+    description: DMA/Interrupt enable register
+  - name: SR
+    byte_offset: 16
+    fieldset: SR_ADV
+    description: status register
+  - name: EGR
+    byte_offset: 20
+    bit_size: 16
+    access: Write
+    fieldset: EGR_ADV
+    description: event generation register
+  - name: CCMR_Input
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Input_2CH
+    description: capture/compare mode register 1-2 (input mode)
+  - name: CCMR_Output
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 24
+    fieldset: CCMR_Output_GP16
+    description: capture/compare mode register 1-2 (output mode)
+  - name: CCER
+    byte_offset: 32
+    fieldset: CCER_ADV
+    description: capture/compare enable register
+  - name: RCR
+    byte_offset: 48
+    bit_size: 16
+    fieldset: RCR_ADV
+    description: repetition counter register
+  - name: CCR
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 52
+    fieldset: CCR_1CH
+    description: capture/compare register x (x=1-4)
+  - name: BDTR
+    byte_offset: 68
+    fieldset: BDTR_ADV
+    description: break and dead-time register
+  - name: TISEL
+    byte_offset: 92
+    fieldset: TISEL_GP16
+    description: input selection register
+  - name: AF1
+    byte_offset: 96
+    fieldset: AF1_ADV
+    description: alternate function register 1
+  - name: AF2
+    byte_offset: 100
+    fieldset: AF2_ADV
+    description: alternate function register 2
+block/TIM_CORE:
+  description: Virtual timer for common part of TIM_BASIC and TIM_1CH
+  items:
+  - name: CR1
+    description: control register 1
+    byte_offset: 0
+    bit_size: 16
+    fieldset: CR1_CORE
+  - name: DIER
+    description: DMA/Interrupt enable register
+    byte_offset: 12
+    fieldset: DIER_CORE
+  - name: SR
+    description: status register
+    byte_offset: 16
+    fieldset: SR_CORE
+  - name: EGR
+    description: event generation register
+    byte_offset: 20
+    access: Write
+    bit_size: 16
+    fieldset: EGR_CORE
+  - name: CNT
+    description: counter
+    byte_offset: 36
+    fieldset: CNT_CORE
+  - name: PSC
+    description: prescaler
+    byte_offset: 40
+    bit_size: 16
+  - name: ARR
+    description: auto-reload register
+    byte_offset: 44
+    fieldset: ARR_CORE
+fieldset/AF1_1CH_CMP:
+  description: alternate function register 1
+  fields:
+  - name: BKINE
+    description: TIMx_BKIN input enable
+    bit_offset: 0
+    bit_size: 1
+  - name: BKCMPE
+    description: TIM_BRK_CMPx (x=1-2) enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: BKDF1BKE
+    description: BRK DFSDM1_BREAKx enable (x=0 if TIM15, x=1 if TIM16, x=2 if TIM17)
+    bit_offset: 8
+    bit_size: 1
+  - name: BKINP
+    description: TIMx_BKIN input polarity
+    bit_offset: 9
+    bit_size: 1
+    enum: BKINP
+  - name: BKCMPP
+    description: TIM_BRK_CMPx (x=1-2) input polarity
+    bit_offset: 10
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+    enum: BKINP
+fieldset/AF1_ADV:
+  extends: AF1_1CH_CMP
+  description: alternate function register 1
+  fields:
+  - name: ETRSEL
+    description: etr_in source selection
+    bit_offset: 14
+    bit_size: 4
+fieldset/AF2_ADV:
+  description: alternate function register 2
+  fields:
+  - name: BK2INE
+    description: TIMx_BKIN2 input enable
+    bit_offset: 0
+    bit_size: 1
+  - name: BK2CMPE
+    description: TIM_BRK2_CMPx (x=1-8) enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 1
+      stride: 8
+  - name: BK2DF1BK1E
+    description: BRK2 DFSDM1_BREAK1 enable
+    bit_offset: 8
+    bit_size: 1
+  - name: BK2INP
+    description: TIMx_BK2IN input polarity
+    bit_offset: 9
+    bit_size: 1
+    enum: BKINP
+  - name: BK2CMPP
+    description: TIM_BRK2_CMPx (x=1-4) input polarity
+    bit_offset: 10
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+    enum: BKINP
+fieldset/ARR_CORE:
+  description: auto-reload register
+  fields:
+  - name: ARR
+    description: Auto-reload value
+    bit_offset: 0
+    bit_size: 16
+fieldset/BDTR_1CH_CMP:
+  description: break and dead-time register
+  fields:
+  - name: DTG
+    description: Dead-time generator setup
+    bit_offset: 0
+    bit_size: 8
+  - name: LOCK
+    description: Lock configuration
+    bit_offset: 8
+    bit_size: 2
+    enum: LOCK
+  - name: OSSI
+    description: Off-state selection for Idle mode
+    bit_offset: 10
+    bit_size: 1
+    enum: OSSI
+  - name: OSSR
+    description: Off-state selection for Run mode
+    bit_offset: 11
+    bit_size: 1
+    enum: OSSR
+  - name: BKE
+    description: Break x (x=1) enable
+    bit_offset: 12
+    bit_size: 1
+    array:
+      len: 1
+      stride: 12
+  - name: BKP
+    description: Break x (x=1) polarity
+    bit_offset: 13
+    bit_size: 1
+    array:
+      len: 1
+      stride: 12
+    enum: BKP
+  - name: AOE
+    description: Automatic output enable
+    bit_offset: 14
+    bit_size: 1
+  - name: MOE
+    description: Main output enable
+    bit_offset: 15
+    bit_size: 1
+  - name: BKF
+    description: Break x (x=1) filter
+    bit_offset: 16
+    bit_size: 4
+    array:
+      len: 1
+      stride: 4
+    enum: FilterValue
+fieldset/BDTR_ADV:
+  extends: BDTR_1CH_CMP
+  description: break and dead-time register
+  fields:
+  - name: BKE
+    description: Break x (x=1,2) enable
+    bit_offset: 12
+    bit_size: 1
+    array:
+      len: 2
+      stride: 12
+  - name: BKP
+    description: Break x (x=1,2) polarity
+    bit_offset: 13
+    bit_size: 1
+    array:
+      len: 2
+      stride: 12
+    enum: BKP
+  - name: BKF
+    description: Break x (x=1,2) filter
+    bit_offset: 16
+    bit_size: 4
+    array:
+      len: 2
+      stride: 4
+    enum: FilterValue
+fieldset/CCER_1CH:
+  description: capture/compare enable register
+  fields:
+  - name: CCE
+    description: Capture/Compare x (x=1) output enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 1
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 1
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1) output Polarity
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 1
+      stride: 4
+fieldset/CCER_2CH:
+  extends: CCER_1CH
+  description: capture/compare enable register
+  fields:
+  - name: CCE
+    description: Capture/Compare x (x=1-2) output enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 2
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1-2) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1-2) output Polarity
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 2
+      stride: 4
+fieldset/CCER_2CH_CMP:
+  extends: CCER_2CH
+  description: capture/compare enable register
+  fields:
+  - name: CCNE
+    description: Capture/Compare x (x=1) complementary output enable
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 1
+      stride: 4
+fieldset/CCER_ADV:
+  extends: CCER_2CH_CMP
+  description: capture/compare enable register
+  fields:
+  - name: CCE
+    description: Capture/Compare x (x=1-6) output enable
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 6
+      stride: 4
+  - name: CCP
+    description: Capture/Compare x (x=1-6) output Polarity
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 6
+      stride: 4
+  - name: CCNE
+    description: Capture/Compare x (x=1-3) complementary output enable
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 3
+      stride: 4
+  - name: CCNP
+    description: Capture/Compare x (x=1-4) output Polarity
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 4
+      stride: 4
+fieldset/CCMR_Input_1CH:
+  description: capture/compare mode register x (x=1) (input mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 1
+      stride: 8
+    enum: CCMR_Input_CCS
+  - name: ICPSC
+    description: Input capture y prescaler
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 1
+      stride: 8
+  - name: ICF
+    description: Input capture y filter
+    bit_offset: 4
+    bit_size: 4
+    array:
+      len: 1
+      stride: 8
+    enum: FilterValue
+fieldset/CCMR_Input_2CH:
+  extends: CCMR_Input_1CH
+  description: capture/compare mode register x (x=1) (input mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Input_CCS
+  - name: ICPSC
+    description: Input capture y prescaler
+    bit_offset: 2
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+  - name: ICF
+    description: Input capture y filter
+    bit_offset: 4
+    bit_size: 4
+    array:
+      len: 2
+      stride: 8
+    enum: FilterValue
+fieldset/CCMR_Output_1CH:
+  description: capture/compare mode register x (x=1) (output mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 1
+      stride: 8
+    enum: CCMR_Output_CCS
+  - name: OCFE
+    description: Output compare y fast enable
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 1
+      stride: 8
+  - name: OCPE
+    description: Output compare y preload enable
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 1
+      stride: 8
+  - name: OCM
+    description: Output compare y mode
+    bit_offset: 4
+    bit_size: 3
+    array:
+      len: 1
+      stride: 8
+    enum: OCM
+fieldset/CCMR_Output_2CH:
+  extends: CCMR_Output_1CH
+  description: capture/compare mode register x (x=1) (output mode)
+  fields:
+  - name: CCS
+    description: Capture/Compare y selection
+    bit_offset: 0
+    bit_size: 2
+    array:
+      len: 2
+      stride: 8
+    enum: CCMR_Output_CCS
+  - name: OCFE
+    description: Output compare y fast enable
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+  - name: OCPE
+    description: Output compare y preload enable
+    bit_offset: 3
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+  - name: OCM
+    description: Output compare y mode
+    bit_offset: 4
+    bit_size: 3
+    array:
+      len: 2
+      stride: 8
+    enum: OCM
+fieldset/CCMR_Output_GP16:
+  extends: CCMR_Output_2CH
+  description: capture/compare mode register x (x=1-2) (output mode)
+  fields:
+  - name: OCCE
+    description: Output compare y clear enable
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 8
+fieldset/CCR_1CH:
+  description: capture/compare register x (x=1-4,6)
+  fields:
+  - name: CCR
+    description: capture/compare x (x=1-4,6) value
+    bit_offset: 0
+    bit_size: 16
+fieldset/CNT_CORE:
+  description: counter
+  fields:
+  - name: CNT
+    description: counter value
+    bit_offset: 0
+    bit_size: 16
+  - name: UIFCPY
+    description: UIF copy
+    bit_offset: 31
+    bit_size: 1
+fieldset/CR1_1CH:
+  extends: CR1_CORE
+  description: control register 1
+  fields:
+  - name: CKD
+    description: Clock division
+    bit_offset: 8
+    bit_size: 2
+    enum: CKD
+fieldset/CR1_CORE:
+  description: control register 1
+  fields:
+  - name: CEN
+    description: Counter enable
+    bit_offset: 0
+    bit_size: 1
+  - name: UDIS
+    description: Update disable
+    bit_offset: 1
+    bit_size: 1
+  - name: URS
+    description: Update request source
+    bit_offset: 2
+    bit_size: 1
+    enum: URS
+  - name: OPM
+    description: One-pulse mode enbaled
+    bit_offset: 3
+    bit_size: 1
+  - name: ARPE
+    description: Auto-reload preload enable
+    bit_offset: 7
+    bit_size: 1
+  - name: UIFREMAP
+    description: UIF status bit remapping enable
+    bit_offset: 11
+    bit_size: 1
+fieldset/CR1_GP16:
+  extends: CR1_CORE
+  description: control register 1
+  fields:
+  - name: DIR
+    description: Direction
+    bit_offset: 4
+    bit_size: 1
+    enum: DIR
+  - name: CMS
+    description: Center-aligned mode selection
+    bit_offset: 5
+    bit_size: 2
+    enum: CMS
+  - name: CKD
+    description: Clock division
+    bit_offset: 8
+    bit_size: 2
+    enum: CKD
+fieldset/CR2_1CH_CMP:
+  description: control register 2
+  fields:
+  - name: CCPC
+    description: Capture/compare preloaded control
+    bit_offset: 0
+    bit_size: 1
+  - name: CCUS
+    description: Capture/compare control update selection
+    bit_offset: 2
+    bit_size: 1
+  - name: CCDS
+    description: Capture/compare DMA selection
+    bit_offset: 3
+    bit_size: 1
+    enum: CCDS
+  - name: OIS
+    description: Output Idle state x (x=1)
+    bit_offset: 8
+    bit_size: 1
+    array:
+      len: 1
+      stride: 2
+  - name: OISN
+    description: Output Idle state x (x=1)
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 1
+      stride: 2
+fieldset/CR2_2CH_CMP:
+  extends: CR2_1CH_CMP
+  description: control register 2
+  fields:
+  - name: MMS
+    description: Master mode selection
+    bit_offset: 4
+    bit_size: 3
+    enum: MMS
+  - name: TI1S
+    description: TI1 selection
+    bit_offset: 7
+    bit_size: 1
+    enum: TI1S
+  - name: OIS
+    description: Output Idle state x (x=1,2)
+    bit_offset: 8
+    bit_size: 1
+    array:
+      len: 2
+      stride: 2
+fieldset/CR2_ADV:
+  extends: CR2_2CH_CMP
+  description: control register 2
+  fields:
+  - name: OIS
+    description: Output Idle state x (x=1-6)
+    bit_offset: 8
+    bit_size: 1
+    array:
+      len: 6
+      stride: 2
+  - name: OISN
+    description: Output Idle state x N x (x=1-4)
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 2
+  - name: MMS2
+    description: Master mode selection 2
+    bit_offset: 20
+    bit_size: 4
+    enum: MMS2
+fieldset/DIER_1CH:
+  extends: DIER_CORE
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1) interrupt enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/DIER_1CH_CMP:
+  extends: DIER_1CH
+  description: DMA/Interrupt enable register
+  fields:
+  - name: COMIE
+    description: COM interrupt enable
+    bit_offset: 5
+    bit_size: 1
+  - name: BIE
+    description: Break interrupt enable
+    bit_offset: 7
+    bit_size: 1
+  - name: UDE
+    description: Update DMA request enable
+    bit_offset: 8
+    bit_size: 1
+  - name: CCDE
+    description: Capture/Compare x (x=1) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/DIER_2CH_CMP:
+  extends: DIER_1CH_CMP
+  description: DMA/Interrupt enable register
+  fields:
+  - name: TIE
+    description: Trigger interrupt enable
+    bit_offset: 6
+    bit_size: 1
+  - name: COMDE
+    description: COM DMA request enable
+    bit_offset: 13
+    bit_size: 1
+  - name: TDE
+    description: Trigger DMA request enable
+    bit_offset: 14
+    bit_size: 1
+fieldset/DIER_ADV:
+  extends: DIER_2CH_CMP
+  description: DMA/Interrupt enable register
+  fields:
+  - name: CCIE
+    description: Capture/Compare x (x=1-4) interrupt enable
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: CCDE
+    description: Capture/Compare x (x=1-4) DMA request enable
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+fieldset/DIER_CORE:
+  description: DMA/Interrupt enable register
+  fields:
+  - name: UIE
+    description: Update interrupt enable
+    bit_offset: 0
+    bit_size: 1
+fieldset/EGR_1CH:
+  extends: EGR_CORE
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/EGR_1CH_CMP:
+  extends: EGR_1CH
+  description: event generation register
+  fields:
+  - name: COMG
+    description: Capture/Compare control update generation
+    bit_offset: 5
+    bit_size: 1
+  - name: BG
+    description: Break x (x=1) generation
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/EGR_2CH_CMP:
+  extends: EGR_1CH_CMP
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1,2) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: TG
+    description: Trigger generation
+    bit_offset: 6
+    bit_size: 1
+fieldset/EGR_ADV:
+  extends: EGR_2CH_CMP
+  description: event generation register
+  fields:
+  - name: CCG
+    description: Capture/compare x (x=1-4) generation
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: BG
+    description: Break x (x=1-2) generation
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+fieldset/EGR_CORE:
+  description: event generation register
+  fields:
+  - name: UG
+    description: Update generation
+    bit_offset: 0
+    bit_size: 1
+fieldset/RCR_ADV:
+  description: repetition counter register
+  fields:
+  - name: REP
+    description: Repetition counter value
+    bit_offset: 0
+    bit_size: 16
+fieldset/SMCR_2CH:
+  description: slave mode control register
+  fields:
+  - name: SMS
+    description: Slave mode selection
+    bit_offset:
+    - start: 0
+      end: 2
+    - start: 16
+      end: 16
+    bit_size: 4
+    enum: SMS
+  - name: TS
+    description: Trigger selection
+    bit_offset:
+    - start: 4
+      end: 6
+    - start: 20
+      end: 21
+    bit_size: 5
+    enum: TS
+  - name: MSM
+    description: Master/Slave mode
+    bit_offset: 7
+    bit_size: 1
+    enum: MSM
+fieldset/SMCR_GP16:
+  extends: SMCR_2CH
+  description: slave mode control register
+  fields:
+  - name: ETF
+    description: External trigger filter
+    bit_offset: 8
+    bit_size: 4
+    enum: FilterValue
+  - name: ETPS
+    description: External trigger prescaler
+    bit_offset: 12
+    bit_size: 2
+    enum: ETPS
+  - name: ECE
+    description: External clock mode 2 enable
+    bit_offset: 14
+    bit_size: 1
+  - name: ETP
+    description: External trigger polarity
+    bit_offset: 15
+    bit_size: 1
+    enum: ETP
+fieldset/SR_1CH:
+  extends: SR_CORE
+  description: status register
+  fields:
+  - name: CCIF
+    description: Capture/compare x (x=1) interrupt flag
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+  - name: CCOF
+    description: Capture/Compare x (x=1) overcapture flag
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/SR_1CH_CMP:
+  extends: SR_1CH
+  description: status register
+  fields:
+  - name: COMIF
+    description: COM interrupt flag
+    bit_offset: 5
+    bit_size: 1
+  - name: BIF
+    description: Break x (x=1) interrupt flag
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 1
+      stride: 1
+fieldset/SR_2CH_CMP:
+  extends: SR_1CH_CMP
+  description: status register
+  fields:
+  - name: CCIF
+    description: Capture/compare x (x=1,2) interrupt flag
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: TIF
+    description: Trigger interrupt flag
+    bit_offset: 6
+    bit_size: 1
+  - name: CCOF
+    description: Capture/Compare x (x=1,2) overcapture flag
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+fieldset/SR_ADV:
+  extends: SR_2CH_CMP
+  description: status register
+  fields:
+  - name: CCIF
+    description: Capture/compare x (x=1-4) interrupt flag
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: BIF
+    description: Break x (x=1,2) interrupt flag
+    bit_offset: 7
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: CCOF
+    description: Capture/Compare x (x=1-4) overcapture flag
+    bit_offset: 9
+    bit_size: 1
+    array:
+      len: 4
+      stride: 1
+  - name: SBIF
+    description: System break interrupt flag
+    bit_offset: 13
+    bit_size: 1
+  - name: CCIF5
+    description: Capture/compare 5 interrupt flag
+    bit_offset: 16
+    bit_size: 1
+  - name: CCIF6
+    description: Capture/compare 6 interrupt flag
+    bit_offset: 17
+    bit_size: 1
+fieldset/SR_CORE:
+  description: status register
+  fields:
+  - name: UIF
+    description: Update interrupt flag
+    bit_offset: 0
+    bit_size: 1
+fieldset/TISEL_1CH:
+  description: input selection register
+  fields:
+  - name: TISEL
+    description: Selects TIM_TIx (x=1) input
+    bit_offset: 0
+    bit_size: 4
+    array:
+      len: 1
+      stride: 8
+fieldset/TISEL_GP16:
+  description: input selection register
+  fields:
+  - name: TISEL
+    description: Selects TIM_TIx (x=1-4) input
+    bit_offset: 0
+    bit_size: 4
+    array:
+      len: 4
+      stride: 8
+enum/BKINP:
+  bit_size: 1
+  variants:
+  - name: NotInverted
+    description: input polarity is not inverted (active low if BKxP = 0, active high
+      if BKxP = 1)
+    value: 0
+  - name: Inverted
+    description: input polarity is inverted (active high if BKxP = 0, active low if
+      BKxP = 1)
+    value: 1
+enum/BKP:
+  bit_size: 1
+  variants:
+  - name: ActiveLow
+    description: Break input tim_brk is active low
+    value: 0
+  - name: ActiveHigh
+    description: Break input tim_brk is active high
+    value: 1
+enum/CCDS:
+  bit_size: 1
+  variants:
+  - name: OnCompare
+    description: CCx DMA request sent when CCx event occurs
+    value: 0
+  - name: OnUpdate
+    description: CCx DMA request sent when update event occurs
+    value: 1
+enum/CCMR_Input_CCS:
+  bit_size: 2
+  variants:
+  - name: TI4
+    description: 'CCx channel is configured as input, normal mapping: ICx mapped to
+      TIx'
+    value: 1
+  - name: TI3
+    description: CCx channel is configured as input, alternate mapping (switches 1 with
+      2, 3 with 4)
+    value: 2
+  - name: TRC
+    description: CCx channel is configured as input, ICx is mapped on TRC
+    value: 3
+enum/CCMR_Output_CCS:
+  bit_size: 2
+  variants:
+  - name: Output
+    description: CCx channel is configured as output
+    value: 0
+enum/CKD:
+  bit_size: 2
+  variants:
+  - name: Div1
+    description: t_DTS = t_CK_INT
+    value: 0
+  - name: Div2
+    description: "t_DTS = 2 \xD7 t_CK_INT"
+    value: 1
+  - name: Div4
+    description: "t_DTS = 4 \xD7 t_CK_INT"
+    value: 2
+enum/CMS:
+  bit_size: 2
+  variants:
+  - name: EdgeAligned
+    description: The counter counts up or down depending on the direction bit
+    value: 0
+  - name: CenterAligned1
+    description: The counter counts up and down alternatively. Output compare interrupt
+      flags are set only when the counter is counting down.
+    value: 1
+  - name: CenterAligned2
+    description: The counter counts up and down alternatively. Output compare interrupt
+      flags are set only when the counter is counting up.
+    value: 2
+  - name: CenterAligned3
+    description: The counter counts up and down alternatively. Output compare interrupt
+      flags are set both when the counter is counting up or down.
+    value: 3
+enum/DIR:
+  bit_size: 1
+  variants:
+  - name: Up
+    description: Counter used as upcounter
+    value: 0
+  - name: Down
+    description: Counter used as downcounter
+    value: 1
+enum/ETP:
+  bit_size: 1
+  variants:
+  - name: NotInverted
+    description: ETR is noninverted, active at high level or rising edge
+    value: 0
+  - name: Inverted
+    description: ETR is inverted, active at low level or falling edge
+    value: 1
+enum/ETPS:
+  bit_size: 2
+  variants:
+  - name: Div1
+    description: Prescaler OFF
+    value: 0
+  - name: Div2
+    description: ETRP frequency divided by 2
+    value: 1
+  - name: Div4
+    description: ETRP frequency divided by 4
+    value: 2
+  - name: Div8
+    description: ETRP frequency divided by 8
+    value: 3
+enum/FilterValue:
+  bit_size: 4
+  variants:
+  - name: NoFilter
+    description: No filter, sampling is done at fDTS
+    value: 0
+  - name: FCK_INT_N2
+    description: fSAMPLING=fCK_INT, N=2
+    value: 1
+  - name: FCK_INT_N4
+    description: fSAMPLING=fCK_INT, N=4
+    value: 2
+  - name: FCK_INT_N8
+    description: fSAMPLING=fCK_INT, N=8
+    value: 3
+  - name: FDTS_Div2_N6
+    description: fSAMPLING=fDTS/2, N=6
+    value: 4
+  - name: FDTS_Div2_N8
+    description: fSAMPLING=fDTS/2, N=8
+    value: 5
+  - name: FDTS_Div4_N6
+    description: fSAMPLING=fDTS/4, N=6
+    value: 6
+  - name: FDTS_Div4_N8
+    description: fSAMPLING=fDTS/4, N=8
+    value: 7
+  - name: FDTS_Div8_N6
+    description: fSAMPLING=fDTS/8, N=6
+    value: 8
+  - name: FDTS_Div8_N8
+    description: fSAMPLING=fDTS/8, N=8
+    value: 9
+  - name: FDTS_Div16_N5
+    description: fSAMPLING=fDTS/16, N=5
+    value: 10
+  - name: FDTS_Div16_N6
+    description: fSAMPLING=fDTS/16, N=6
+    value: 11
+  - name: FDTS_Div16_N8
+    description: fSAMPLING=fDTS/16, N=8
+    value: 12
+  - name: FDTS_Div32_N5
+    description: fSAMPLING=fDTS/32, N=5
+    value: 13
+  - name: FDTS_Div32_N6
+    description: fSAMPLING=fDTS/32, N=6
+    value: 14
+  - name: FDTS_Div32_N8
+    description: fSAMPLING=fDTS/32, N=8
+    value: 15
+enum/LOCK:
+  bit_size: 2
+  variants:
+  - name: Disabled
+    description: No bit is write protected
+    value: 0
+  - name: Level1
+    description: DTG bits in TIMx_BDTR register, OISx and OISxN bits in TIMx_CR2 register
+      and BKBID/BKE/BKP/AOE bits in TIMx_BDTR register can no longer be written
+    value: 1
+  - name: Level2
+    description: LOCK Level 1 + CC Polarity bits (CCxP/CCxNP bits in TIMx_CCER register,
+      as long as the related channel is configured in output through the CCxS bits)
+      as well as OSSR and OSSI bits can no longer be written.
+    value: 2
+  - name: Level3
+    description: LOCK Level 2 + CC Control bits (OCxM and OCxPE bits in TIMx_CCMRx registers,
+      as long as the related channel is configured in output through the CCxS bits)
+      can no longer be written.
+    value: 3
+enum/MMS:
+  bit_size: 3
+  variants:
+  - name: Reset
+    description: The UG bit from the TIMx_EGR register is used as trigger output
+    value: 0
+  - name: Enable
+    description: The counter enable signal, CNT_EN, is used as trigger output
+    value: 1
+  - name: Update
+    description: The update event is selected as trigger output
+    value: 2
+  - name: ComparePulse
+    description: The trigger output send a positive pulse when the CC1IF flag it to
+      be set, as soon as a capture or a compare match occurred
+    value: 3
+  - name: CompareOC1
+    description: OC1REF signal is used as trigger output
+    value: 4
+  - name: CompareOC2
+    description: OC2REF signal is used as trigger output
+    value: 5
+  - name: CompareOC3
+    description: OC3REF signal is used as trigger output
+    value: 6
+  - name: CompareOC4
+    description: OC4REF signal is used as trigger output
+    value: 7
+enum/MMS2:
+  bit_size: 4
+  variants:
+  - name: Reset
+    description: The UG bit from the TIMx_EGR register is used as TRGO2
+    value: 0
+  - name: Enable
+    description: The counter enable signal, CNT_EN, is used as TRGO2
+    value: 1
+  - name: Update
+    description: The update event is selected as TRGO2
+    value: 2
+  - name: ComparePulse
+    description: TRGO2 send a positive pulse when the CC1IF flag it to be set, as soon
+      as a capture or a compare match occurred
+    value: 3
+  - name: CompareOC1
+    description: OC1REF signal is used as TRGO2
+    value: 4
+  - name: CompareOC2
+    description: OC2REF signal is used as TRGO2
+    value: 5
+  - name: CompareOC3
+    description: OC3REF signal is used as TRGO2
+    value: 6
+  - name: CompareOC4
+    description: OC4REF signal is used as TRGO2
+    value: 7
+  - name: CompareOC5
+    description: OC5REF signal is used as TRGO2
+    value: 8
+  - name: CompareOC6
+    description: OC6REF signal is used as TRGO2
+    value: 9
+  - name: ComparePulse_OC4
+    description: OC4REF rising or falling edges generate pulses on TRGO2
+    value: 10
+  - name: ComparePulse_OC6
+    description: OC6REF rising or falling edges generate pulses on TRGO2
+    value: 11
+  - name: ComparePulse_OC4_Or_OC6_Rising
+    description: OC4REF or OC6REF rising edges generate pulses on TRGO2
+    value: 12
+  - name: ComparePulse_OC4_Rising_Or_OC6_Falling
+    description: OC4REF rising or OC6REF falling edges generate pulses on TRGO2
+    value: 13
+  - name: ComparePulse_OC5_Or_OC6_Rising
+    description: OC5REF or OC6REF rising edges generate pulses on TRGO2
+    value: 14
+  - name: ComparePulse_OC5_Rising_Or_OC6_Falling
+    description: OC5REF rising or OC6REF falling edges generate pulses on TRGO2
+    value: 15
+enum/MSM:
+  bit_size: 1
+  variants:
+  - name: NoSync
+    description: No action
+    value: 0
+  - name: Sync
+    description: The effect of an event on the trigger input (TRGI) is delayed to allow
+      a perfect synchronization between the current timer and its slaves (through TRGO).
+      It is useful if we want to synchronize several timers on a single external event.
+    value: 1
+enum/OCM:
+  bit_size: 3
+  variants:
+  - name: Frozen
+    description: The comparison between the output compare register TIMx_CCRy and the
+      counter TIMx_CNT has no effect on the outputs
+    value: 0
+  - name: ActiveOnMatch
+    description: Set channel to active level on match. OCyREF signal is forced high
+      when the counter matches the capture/compare register
+    value: 1
+  - name: InactiveOnMatch
+    description: Set channel to inactive level on match. OCyREF signal is forced low
+      when the counter matches the capture/compare register
+    value: 2
+  - name: Toggle
+    description: OCyREF toggles when TIMx_CNT=TIMx_CCRy
+    value: 3
+  - name: ForceInactive
+    description: OCyREF is forced low
+    value: 4
+  - name: ForceActive
+    description: OCyREF is forced high
+    value: 5
+  - name: PwmMode1
+    description: In upcounting, channel is active as long as TIMx_CNT<TIMx_CCRy else
+      inactive. In downcounting, channel is inactive as long as TIMx_CNT>TIMx_CCRy else
+      active
+    value: 6
+  - name: PwmMode2
+    description: Inversely to PwmMode1
+    value: 7
+enum/OSSI:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: When inactive, OC/OCN outputs are disabled
+    value: 0
+  - name: IdleLevel
+    description: When inactive, OC/OCN outputs are forced to idle level
+    value: 1
+enum/OSSR:
+  bit_size: 1
+  variants:
+  - name: Disabled
+    description: When inactive, OC/OCN outputs are disabled
+    value: 0
+  - name: IdleLevel
+    description: When inactive, OC/OCN outputs are enabled with their inactive level
+    value: 1
+enum/SMS:
+  bit_size: 4
+  variants:
+  - name: Disabled
+    description: Slave mode disabled - if CEN = '1' then the prescaler is clocked directly
+      by the internal clock.
+    value: 0
+  - name: Encoder_Mode_1
+    description: Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on
+      TI1FP2 level.
+    value: 1
+  - name: Encoder_Mode_2
+    description: Encoder mode 2 - Counter counts up/down on TI1FP2 edge depending on
+      TI2FP1 level.
+    value: 2
+  - name: Encoder_Mode_3
+    description: Encoder mode 3 - Counter counts up/down on both TI1FP1 and TI2FP2 edges
+      depending on the level of the other input.
+    value: 3
+  - name: Reset_Mode
+    description: Reset Mode - Rising edge of the selected trigger input (TRGI) reinitializes
+      the counter and generates an update of the registers.
+    value: 4
+  - name: Gated_Mode
+    description: Gated Mode - The counter clock is enabled when the trigger input (TRGI)
+      is high. The counter stops (but is not reset) as soon as the trigger becomes low.
+      Both start and stop of the counter are controlled.
+    value: 5
+  - name: Trigger_Mode
+    description: Trigger Mode - The counter starts at a rising edge of the trigger TRGI
+      (but it is not reset). Only the start of the counter is controlled.
+    value: 6
+  - name: Ext_Clock_Mode
+    description: External Clock Mode 1 - Rising edges of the selected trigger (TRGI)
+      clock the counter.
+    value: 7
+  - name: Combined_Reset_Trigger
+    description: Rising edge of the selected trigger input (tim_trgi) reinitializes
+      the counter, generates an update of the registers and starts the counter.
+    value: 8
+enum/TI1S:
+  bit_size: 1
+  variants:
+  - name: Normal
+    description: The TIMx_CH1 pin is connected to TI1 input
+    value: 0
+  - name: XOR
+    description: The TIMx_CH1, CH2, CH3 pins are connected to TI1 input
+    value: 1
+enum/TS:
+  bit_size: 5
+  variants:
+  - name: ITR0
+    description: Internal Trigger 0
+    value: 0
+  - name: ITR1
+    description: Internal Trigger 1
+    value: 1
+  - name: ITR2
+    description: Internal Trigger 2
+    value: 2
+  - name: ITR3
+    description: Internal Trigger 3
+    value: 3
+  - name: TI1F_ED
+    description: TI1 Edge Detector
+    value: 4
+  - name: TI1FP1
+    description: Filtered Timer Input 1
+    value: 5
+  - name: TI2FP2
+    description: Filtered Timer Input 2
+    value: 6
+  - name: ETRF
+    description: External Trigger input
+    value: 7
+enum/URS:
+  bit_size: 1
+  variants:
+  - name: AnyEvent
+    description: Any of counter overflow/underflow, setting UG, or update through slave
+      mode, generates an update interrupt or DMA request
+    value: 0
+  - name: CounterOnly
+    description: Only counter overflow/underflow generates an update interrupt or DMA
+      request
+    value: 1

--- a/data/registers/usart_v2.yaml
+++ b/data/registers/usart_v2.yaml
@@ -1,0 +1,206 @@
+block/UART:
+  description: Universal asynchronous receiver transmitter (MS32C001B new IP)
+  items:
+  - name: DR
+    description: Receive/send data register
+    byte_offset: 0
+    fieldset: DR
+  - name: BRR
+    description: Baud rate register
+    byte_offset: 4
+    fieldset: BRR
+  - name: SR
+    description: Status register
+    byte_offset: 16
+    fieldset: SR
+  - name: CR1
+    description: Control register 1
+    byte_offset: 20
+    fieldset: CR1
+  - name: CR2
+    description: Control register 2
+    byte_offset: 24
+    fieldset: CR2
+  - name: CR3
+    description: Control register 3
+    byte_offset: 28
+    fieldset: CR3
+  - name: RAR
+    description: Receive address matching register
+    byte_offset: 32
+    fieldset: RAR
+  - name: TAR
+    description: Transmit address matching register
+    byte_offset: 36
+    fieldset: TAR
+  - name: BRRF
+    description: Baud rate fractional register
+    byte_offset: 40
+    fieldset: BRRF
+fieldset/BRR:
+  description: Baud rate register
+  fields:
+  - name: BRR
+    description: Baud rate register
+    bit_offset: 0
+    bit_size: 16
+fieldset/BRRF:
+  description: Baud rate fractional register
+  fields:
+  - name: BRRF
+    description: Baud rate fractional register
+    bit_offset: 0
+    bit_size: 4
+fieldset/CR1:
+  description: Control register 1
+  fields:
+  - name: M
+    description: Data Length Select
+    bit_offset: 0
+    bit_size: 2
+  - name: STOP
+    description: Number of stop bits
+    bit_offset: 2
+    bit_size: 1
+  - name: PCE
+    description: Parity Enable
+    bit_offset: 3
+    bit_size: 1
+  - name: PS
+    description: Even Parity Select
+    bit_offset: 4
+    bit_size: 1
+  - name: SP
+    description: Stick Parity
+    bit_offset: 5
+    bit_size: 1
+  - name: SBK
+    description: Send Break
+    bit_offset: 6
+    bit_size: 1
+  - name: SWAP
+    description: TX/RX pin swap
+    bit_offset: 8
+    bit_size: 1
+  - name: MSBFIRST
+    description: MSB first mode
+    bit_offset: 9
+    bit_size: 1
+fieldset/CR2:
+  description: Control register 2
+  fields:
+  - name: RXNEIE
+    description: Enable Received Data Available Interrupt
+    bit_offset: 0
+    bit_size: 1
+  - name: TDREIE
+    description: Enable Transmit Holding Register Empty Interrupt
+    bit_offset: 1
+    bit_size: 1
+  - name: LSIE
+    description: Enable Receiver Line Status Interrupt
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSYERRIE
+    description: Enable Busyerr state interruption
+    bit_offset: 3
+    bit_size: 1
+  - name: TXEIE
+    description: Enable tx empty interruption
+    bit_offset: 4
+    bit_size: 1
+fieldset/CR3:
+  description: Control register 3
+  fields:
+  - name: M_E
+    description: Extension for DLS
+    bit_offset: 0
+    bit_size: 1
+  - name: ADDR_MATCH
+    description: Address Match Mode
+    bit_offset: 1
+    bit_size: 1
+  - name: SEND_ADDR
+    description: Send address control bit
+    bit_offset: 2
+    bit_size: 1
+  - name: TX_MODE
+    description: Transmit mode control bit
+    bit_offset: 3
+    bit_size: 1
+  - name: DMAR
+    description: DMA receive enable
+    bit_offset: 4
+    bit_size: 1
+  - name: DMAT
+    description: DMA transmit enable
+    bit_offset: 5
+    bit_size: 1
+  - name: DMA_SOFT_ACK
+    description: DMA software ack
+    bit_offset: 6
+    bit_size: 1
+fieldset/DR:
+  description: Receive/send data register
+  fields:
+  - name: DR
+    description: Receive/send data register
+    bit_offset: 0
+    bit_size: 9
+fieldset/RAR:
+  description: Receive address matching register
+  fields:
+  - name: RAR
+    description: Receive address matching register
+    bit_offset: 0
+    bit_size: 8
+fieldset/SR:
+  description: Status register
+  fields:
+  - name: RXNE
+    description: Receive register not empty
+    bit_offset: 0
+    bit_size: 1
+  - name: ORE
+    description: Overrun error bit
+    bit_offset: 1
+    bit_size: 1
+  - name: PE
+    description: Parity Error bit
+    bit_offset: 2
+    bit_size: 1
+  - name: FE
+    description: Framing Error bit
+    bit_offset: 3
+    bit_size: 1
+  - name: BRI
+    description: Break Interrupt bit
+    bit_offset: 4
+    bit_size: 1
+  - name: TDRE
+    description: Transmit Holding Register Empty bit
+    bit_offset: 5
+    bit_size: 1
+  - name: TXE
+    description: Transmitter Empty bit
+    bit_offset: 6
+    bit_size: 1
+  - name: ADDR_RCVD
+    description: Address Received Bit
+    bit_offset: 8
+    bit_size: 1
+  - name: BUSY
+    description: UART Busy
+    bit_offset: 9
+    bit_size: 1
+  - name: BUSY_ERR
+    description: Busy Detect Error
+    bit_offset: 10
+    bit_size: 1
+fieldset/TAR:
+  description: Transmit address matching register
+  fields:
+  - name: TAR
+    description: Transmit address matching register
+    bit_offset: 0
+    bit_size: 8

--- a/data/registers/vref_v1.yaml
+++ b/data/registers/vref_v1.yaml
@@ -1,0 +1,18 @@
+block/VREF:
+  description: Voltage reference buffer (MS32C001B)
+  items:
+  - name: CR
+    description: VREF control register
+    byte_offset: 0
+    fieldset: CR
+fieldset/CR:
+  description: VREF control register
+  fields:
+  - name: VREFBUF_OUT_SEL
+    description: VREFBUF output level selection
+    bit_offset: 0
+    bit_size: 2
+  - name: VREFBUF_EN
+    description: VREFBUF enable
+    bit_offset: 3
+    bit_size: 1

--- a/data/series/MS32C001.yaml
+++ b/data/series/MS32C001.yaml
@@ -1,0 +1,12 @@
+die: DIE002B
+disabled_peripherals:
+- COMP1
+- COMP2
+- I2C1
+- SPI1
+- USART1
+disabled_interrupts:
+- I2C1
+- SPI1
+- USART1
+family: Low-Cost

--- a/data/series/MS32C001B.yaml
+++ b/data/series/MS32C001B.yaml
@@ -1,0 +1,4 @@
+die: DIE001B
+disabled_peripherals: []
+disabled_interrupts: []
+family: Low-Cost

--- a/py32-data-gen/src/main.rs
+++ b/py32-data-gen/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap()
         .filter_map(|res| res.unwrap().file_name().to_str().map(|s| s.to_string()))
         .filter(|s| s.ends_with(".yaml"))
-        .filter(|s| s.starts_with("PY32"))
+        .filter(|s| s.starts_with("PY32") || s.starts_with("MS32"))
         .map(|s| s.strip_suffix(".yaml").unwrap().to_string())
         .collect();
     chip_meta_files.sort();
@@ -67,15 +67,24 @@ fn main() -> anyhow::Result<()> {
     println!("chips: {:?}", chip_meta_files);
 
     std::fs::create_dir_all("build/data/chips")?;
-    
+
     // Caching loaded files to avoid re-reading
     let mut generics: HashMap<String, Generic> = HashMap::new();
     let mut series_map: HashMap<String, Series> = HashMap::new();
-    let mut die_peripherals: HashMap<String, Vec<py32_data_serde::chip::core::Peripheral>> = HashMap::new();
-    let mut die_interrupts: HashMap<String, Vec<py32_data_serde::chip::core::Interrupt>> = HashMap::new();
-    let mut die_dma_channels: HashMap<String, Vec<py32_data_serde::chip::core::DmaChannels>> = HashMap::new();
-    let mut die_afs: HashMap<String, HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Pin>>> = HashMap::new();
-    let mut die_dma_requests: HashMap<String, HashMap<String, Vec<py32_data_serde::chip::core::peripheral::DmaChannel>>> = HashMap::new();
+    let mut die_peripherals: HashMap<String, Vec<py32_data_serde::chip::core::Peripheral>> =
+        HashMap::new();
+    let mut die_interrupts: HashMap<String, Vec<py32_data_serde::chip::core::Interrupt>> =
+        HashMap::new();
+    let mut die_dma_channels: HashMap<String, Vec<py32_data_serde::chip::core::DmaChannels>> =
+        HashMap::new();
+    let mut die_afs: HashMap<
+        String,
+        HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Pin>>,
+    > = HashMap::new();
+    let mut die_dma_requests: HashMap<
+        String,
+        HashMap<String, Vec<py32_data_serde::chip::core::peripheral::DmaChannel>>,
+    > = HashMap::new();
     let mut processed_generics = HashSet::new();
 
     for name in &chip_meta_files {
@@ -93,7 +102,7 @@ fn main() -> anyhow::Result<()> {
             generics.insert(chip_cfg.generic.clone(), g.clone());
             g
         };
-        
+
         // Load series
         let series = if let Some(s) = series_map.get(&generic.series) {
             s.clone()
@@ -104,64 +113,68 @@ fn main() -> anyhow::Result<()> {
             series_map.insert(generic.series.clone(), s.clone());
             s
         };
-        
+
         let die_name = &series.die;
-        
+
         // Load die components
         if !die_peripherals.contains_key(die_name) {
             let p_path = data_dir.join(format!("dies/{}/peripherals.yaml", die_name));
             if p_path.exists() {
                 let p_content = std::fs::read_to_string(&p_path)?;
-                let peris: Vec<py32_data_serde::chip::core::Peripheral> = serde_yaml::from_str(&p_content)?;
+                let peris: Vec<py32_data_serde::chip::core::Peripheral> =
+                    serde_yaml::from_str(&p_content)?;
                 die_peripherals.insert(die_name.clone(), peris);
             } else {
                 die_peripherals.insert(die_name.clone(), vec![]);
             }
         }
-        
+
         if !die_interrupts.contains_key(die_name) {
             let i_path = data_dir.join(format!("dies/{}/interrupts.yaml", die_name));
             if i_path.exists() {
                 let i_content = std::fs::read_to_string(&i_path)?;
-                let mut ints: Vec<py32_data_serde::chip::core::Interrupt> = serde_yaml::from_str(&i_content)?;
+                let mut ints: Vec<py32_data_serde::chip::core::Interrupt> =
+                    serde_yaml::from_str(&i_content)?;
                 ints.sort_by_key(|i| i.number);
                 die_interrupts.insert(die_name.clone(), ints);
             } else {
                 die_interrupts.insert(die_name.clone(), vec![]);
             }
         }
-        
+
         if !die_dma_channels.contains_key(die_name) {
             let d_path = data_dir.join(format!("dies/{}/dma_channels.yaml", die_name));
             if d_path.exists() {
                 let d_content = std::fs::read_to_string(&d_path)?;
-                let dmas: Vec<py32_data_serde::chip::core::DmaChannels> = serde_yaml::from_str(&d_content)?;
+                let dmas: Vec<py32_data_serde::chip::core::DmaChannels> =
+                    serde_yaml::from_str(&d_content)?;
                 die_dma_channels.insert(die_name.clone(), dmas);
             } else {
                 die_dma_channels.insert(die_name.clone(), vec![]);
             }
         }
-        
+
         if !die_afs.contains_key(die_name) {
             let af_path = data_dir.join(format!("dies/{}/af.yaml", die_name));
             if af_path.exists() {
                 let content = std::fs::read_to_string(&af_path)?;
-                let afs: HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Pin>> = serde_yaml::from_str(&content)?;
+                let afs: HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Pin>> =
+                    serde_yaml::from_str(&content)?;
                 die_afs.insert(die_name.clone(), afs);
             } else {
                 die_afs.insert(die_name.clone(), HashMap::new());
             }
         }
-        
+
         if !die_dma_requests.contains_key(die_name) {
             let req_path = data_dir.join(format!("dies/{}/dma_requests.yaml", die_name));
             let mut peripheral_dma_reqs = HashMap::new();
             if req_path.exists() {
                 let content = std::fs::read_to_string(&req_path)?;
                 let reqs: HashMap<String, u8> = serde_yaml::from_str(&content)?;
-                
+
                 let physical_channels = die_dma_channels.get(die_name).unwrap();
-                
+
                 for (signal, &remap) in &reqs {
                     let parts: Vec<&str> = signal.split('_').collect();
                     let (peripheral, sig) = if parts.len() == 1 {
@@ -171,7 +184,7 @@ fn main() -> anyhow::Result<()> {
                     } else {
                         panic!("Invalid DMA signal: {}", signal);
                     };
-                    
+
                     if physical_channels.is_empty() {
                         let dma_channel = py32_data_serde::chip::core::peripheral::DmaChannel {
                             signal: sig.clone(),
@@ -201,12 +214,12 @@ fn main() -> anyhow::Result<()> {
             }
             die_dma_requests.insert(die_name.clone(), peripheral_dma_reqs);
         }
-        
+
         // Build the Core
         let mut final_peripherals = Vec::new();
         let current_afs = die_afs.get(die_name).unwrap();
         let current_dma_reqs = die_dma_requests.get(die_name).unwrap();
-        
+
         for mut p in die_peripherals.get(die_name).unwrap().clone() {
             if !series.disabled_peripherals.contains(&p.name) {
                 // inject afs
@@ -217,7 +230,7 @@ fn main() -> anyhow::Result<()> {
                 if let Some(reqs) = current_dma_reqs.get(&p.name) {
                     p.dma_channels = reqs.clone();
                 }
-                
+
                 // remove unused peripherals
                 if let Some(registers) = &p.registers {
                     let path = Path::new(data_dir)
@@ -231,16 +244,16 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        
+
         let mut final_interrupts = Vec::new();
         for i in die_interrupts.get(die_name).unwrap() {
             if !series.disabled_interrupts.contains(&i.name) {
                 final_interrupts.push(i.clone());
             }
         }
-        
+
         let final_dma_channels = die_dma_channels.get(die_name).unwrap().clone();
-        
+
         let core = py32_data_serde::chip::Core {
             name: "cm0p".to_string(), // Py32 uses Cortex-M0+
             peripherals: final_peripherals,
@@ -272,7 +285,7 @@ fn main() -> anyhow::Result<()> {
         );
         let dump = serde_json::to_string_pretty(&chip)?;
         std::fs::write(format!("build/data/chips/{name}.json"), dump)?;
-        
+
         if processed_generics.insert(chip_cfg.generic.clone()) {
             let generic_chip = Chip {
                 name: chip_cfg.generic.clone(),
@@ -285,7 +298,10 @@ fn main() -> anyhow::Result<()> {
                 cores: vec![core.clone()],
             };
             let gen_dump = serde_json::to_string_pretty(&generic_chip)?;
-            std::fs::write(format!("build/data/chips/{}.json", chip_cfg.generic), gen_dump)?;
+            std::fs::write(
+                format!("build/data/chips/{}.json", chip_cfg.generic),
+                gen_dump,
+            )?;
         }
     }
 

--- a/py32-metapac-gen/res/build.rs
+++ b/py32-metapac-gen/res/build.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let chip_core_name = match env::vars()
         .map(|(a, _)| a)
-        .filter(|x| x.starts_with("CARGO_FEATURE_PY32"))
+        .filter(|x| x.starts_with("CARGO_FEATURE_PY32") || x.starts_with("CARGO_FEATURE_MS32"))
         .get_one()
     {
         Ok(x) => x,
@@ -54,7 +54,10 @@ fn main() {
         crate_dir.display(),
         chip_core_name
     );
-    println!("cargo:rustc-env=PY32_METAPAC_PAC_PATH=chips/{}/pac.rs", chip_core_name);
+    println!(
+        "cargo:rustc-env=PY32_METAPAC_PAC_PATH=chips/{}/pac.rs",
+        chip_core_name
+    );
     println!(
         "cargo:rustc-env=PY32_METAPAC_METADATA_PATH=chips/{}/metadata.rs",
         chip_core_name

--- a/py32-metapac-gen/src/data.rs
+++ b/py32-metapac-gen/src/data.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use py32_data_macros::EnumDebug;
+use serde::Deserialize;
 
 pub mod ir {
     use super::*;
@@ -24,19 +24,25 @@ pub mod ir {
                             name: item.name.clone(),
                             description: item.description.clone(),
                             array: item.array.as_ref().map(|array| match &array {
-                                chiptool::ir::Array::Regular(regular_array) => Array::Regular(RegularArray {
-                                    len: regular_array.len,
-                                    stride: regular_array.stride,
-                                }),
-                                chiptool::ir::Array::Cursed(cursed_array) => Array::Cursed(CursedArray {
-                                    offsets: cursed_array.offsets.clone(),
-                                }),
+                                chiptool::ir::Array::Regular(regular_array) => {
+                                    Array::Regular(RegularArray {
+                                        len: regular_array.len,
+                                        stride: regular_array.stride,
+                                    })
+                                }
+                                chiptool::ir::Array::Cursed(cursed_array) => {
+                                    Array::Cursed(CursedArray {
+                                        offsets: cursed_array.offsets.clone(),
+                                    })
+                                }
                             }),
                             byte_offset: item.byte_offset,
                             inner: match &item.inner {
-                                chiptool::ir::BlockItemInner::Block(block) => BlockItemInner::Block(BlockItemBlock {
-                                    block: block.block.clone(),
-                                }),
+                                chiptool::ir::BlockItemInner::Block(block) => {
+                                    BlockItemInner::Block(BlockItemBlock {
+                                        block: block.block.clone(),
+                                    })
+                                }
                                 chiptool::ir::BlockItemInner::Register(register) => {
                                     BlockItemInner::Register(Register {
                                         access: match register.access {
@@ -45,10 +51,9 @@ pub mod ir {
                                             chiptool::ir::Access::Write => Access::Write,
                                         },
                                         bit_size: register.bit_size,
-                                        fieldset: register
-                                            .fieldset
-                                            .as_ref()
-                                            .map(|fieldset| fieldset.strip_prefix("regs::").unwrap().to_string()),
+                                        fieldset: register.fieldset.as_ref().map(|fieldset| {
+                                            fieldset.strip_prefix("regs::").unwrap().to_string()
+                                        }),
                                     })
                                 }
                             },
@@ -82,23 +87,28 @@ pub mod ir {
                                     BitOffset::Regular(RegularBitOffset { offset: *offset })
                                 }
                                 chiptool::ir::BitOffset::Cursed(ranges) => {
-                                    BitOffset::Cursed(CursedBitOffset { ranges: ranges.clone() })
+                                    BitOffset::Cursed(CursedBitOffset {
+                                        ranges: ranges.clone(),
+                                    })
                                 }
                             },
                             bit_size: field.bit_size,
                             array: field.array.as_ref().map(|array| match &array {
-                                chiptool::ir::Array::Regular(regular_array) => Array::Regular(RegularArray {
-                                    len: regular_array.len,
-                                    stride: regular_array.stride,
-                                }),
-                                chiptool::ir::Array::Cursed(cursed_array) => Array::Cursed(CursedArray {
-                                    offsets: cursed_array.offsets.clone(),
-                                }),
+                                chiptool::ir::Array::Regular(regular_array) => {
+                                    Array::Regular(RegularArray {
+                                        len: regular_array.len,
+                                        stride: regular_array.stride,
+                                    })
+                                }
+                                chiptool::ir::Array::Cursed(cursed_array) => {
+                                    Array::Cursed(CursedArray {
+                                        offsets: cursed_array.offsets.clone(),
+                                    })
+                                }
                             }),
-                            enumm: field
-                                .enumm
-                                .as_ref()
-                                .map(|fieldset| fieldset.strip_prefix("vals::").unwrap().to_string()),
+                            enumm: field.enumm.as_ref().map(|fieldset| {
+                                fieldset.strip_prefix("vals::").unwrap().to_string()
+                            }),
                         })
                         .collect();
 

--- a/py32-metapac-gen/src/lib.rs
+++ b/py32-metapac-gen/src/lib.rs
@@ -57,7 +57,12 @@ impl Gen {
 
         let mut peripheral_versions: BTreeMap<String, String> = BTreeMap::new();
 
-        let gpio_base = core.peripherals.iter().find(|p| p.name == "GPIOA").unwrap().address as u32;
+        let gpio_base = core
+            .peripherals
+            .iter()
+            .find(|p| p.name == "GPIOA")
+            .unwrap()
+            .address as u32;
         let gpio_stride = 0x400;
 
         for p in &core.peripherals {
@@ -71,7 +76,9 @@ impl Gen {
             };
 
             if let Some(bi) = &p.registers {
-                if let Some(old_version) = peripheral_versions.insert(bi.kind.clone(), bi.version.clone()) {
+                if let Some(old_version) =
+                    peripheral_versions.insert(bi.kind.clone(), bi.version.clone())
+                {
                     if old_version != bi.version {
                         panic!(
                             "Peripheral {} has multiple versions: {} and {}",
@@ -107,7 +114,8 @@ impl Gen {
         );
 
         for (module, version) in &peripheral_versions {
-            self.all_peripheral_versions.insert((module.clone(), version.clone()));
+            self.all_peripheral_versions
+                .insert((module.clone(), version.clone()));
             writeln!(
                 &mut extra,
                 "#[path=\"../../peripherals/{}_{}.rs\"] pub mod {};",
@@ -129,21 +137,30 @@ impl Gen {
             .reduce(|acc, item| acc + item)
             .unwrap();
 
-        writeln!(&mut extra, "pub const FLASH_BASE: usize = {};", first_flash.address).unwrap();
-        writeln!(&mut extra, "pub const FLASH_SIZE: usize = {};", total_flash_size).unwrap();
+        writeln!(
+            &mut extra,
+            "pub const FLASH_BASE: usize = {};",
+            first_flash.address
+        )
+        .unwrap();
+        writeln!(
+            &mut extra,
+            "pub const FLASH_SIZE: usize = {};",
+            total_flash_size
+        )
+        .unwrap();
 
         let page_sizes: HashSet<_> = flash_regions
             .iter()
             .map(|r| r.settings.as_ref().unwrap().page_size)
             .collect();
         assert_eq!(1, page_sizes.len());
-        
-        let sector_sizes: HashSet<_> = flash_regions
-        .iter()
-        .map(|r| r.settings.as_ref().unwrap().sector_size)
-        .collect();
-            assert_eq!(1, sector_sizes.len());
 
+        let sector_sizes: HashSet<_> = flash_regions
+            .iter()
+            .map(|r| r.settings.as_ref().unwrap().sector_size)
+            .collect();
+        assert_eq!(1, sector_sizes.len());
 
         writeln!(
             &mut extra,
@@ -265,7 +282,11 @@ impl Gen {
     }
 
     fn load_chip(&mut self, name: &str) -> Chip {
-        let chip_path = self.opts.data_dir.join("chips").join(format!("{}.json", name));
+        let chip_path = self
+            .opts
+            .data_dir
+            .join("chips")
+            .join(format!("{}.json", name));
         let chip = fs::read(chip_path).unwrap_or_else(|_| panic!("Could not load chip {}", name));
         serde_json::from_slice(&chip).unwrap()
     }
@@ -319,7 +340,9 @@ impl Gen {
 
             let mut ir: ir::IR = serde_json::from_reader(File::open(regs_path).unwrap()).unwrap();
 
-            transform::expand_extends::ExpandExtends {}.run(&mut ir).unwrap();
+            transform::expand_extends::ExpandExtends {}
+                .run(&mut ir)
+                .unwrap();
 
             transform::map_names(&mut ir, |k, s| match k {
                 transform::NameKind::Block => *s = s.to_string(),
@@ -395,11 +418,19 @@ impl Gen {
         // Generate src/all_peripheral_versions.rs
         {
             let contents = gen_all_peripheral_versions(&self.all_peripheral_versions);
-            fs::write(self.opts.out_dir.join("src/all_peripheral_versions.rs"), contents).unwrap();
+            fs::write(
+                self.opts.out_dir.join("src/all_peripheral_versions.rs"),
+                contents,
+            )
+            .unwrap();
         }
 
         // copy misc files
-        fs::write(self.opts.out_dir.join("build.rs"), include_bytes!("../res/build.rs")).unwrap();
+        fs::write(
+            self.opts.out_dir.join("build.rs"),
+            include_bytes!("../res/build.rs"),
+        )
+        .unwrap();
         fs::write(
             self.opts.out_dir.join("README.md"),
             include_bytes!("../res/README.md"),
@@ -469,7 +500,11 @@ fn gen_memory_x(out_dir: &Path, chip: &Chip) {
 }
 
 fn get_memory_range(chip: &Chip, kind: MemoryRegionKind) -> (u32, u32, String) {
-    let mut mems: Vec<_> = chip.memory.iter().filter(|m| m.kind == kind && m.size != 0).collect();
+    let mut mems: Vec<_> = chip
+        .memory
+        .iter()
+        .filter(|m| m.kind == kind && m.size != 0)
+        .collect();
     mems.sort_by_key(|m| m.address);
 
     let mut start = u32::MAX;
@@ -477,7 +512,6 @@ fn get_memory_range(chip: &Chip, kind: MemoryRegionKind) -> (u32, u32, String) {
     let mut names = Vec::new();
     let mut best: Option<(u32, u32, String)> = None;
     for m in mems {
-
         if m.address != end {
             names = Vec::new();
             start = m.address;

--- a/svd/MS32C000Axx.svd
+++ b/svd/MS32C000Axx.svd
@@ -1,0 +1,4091 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>MS</vendor>
+  <vendorID>MS</vendorID>
+  <name>ms32c000axx</name>
+  <series>MS32C</series>
+  <version>1.0.0</version>
+  <description>Arm 32-bit Cortex-M0+ Microcontroller based device, CPU clock up to 48 MHz.</description>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x0</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>ADC</name>
+      <description>Analog to Digital Converter</description>
+      <groupName>ADC</groupName>
+      <baseAddress>0x40012400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <description>ADC Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>ADC interrupt and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>EOSMP</name>
+              <description>ADC group regular end of sampling flag</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EOC</name>
+              <description>ADC group regular end of unitary conversion flag</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EOSEQ</name>
+              <description>ADC group regular end of sequence conversions flag</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>ADC group regular overrun flag</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>AWD</name>
+              <description>ADC analog watchdog flag</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>ADC interrupt enable register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>EOSMPIE</name>
+              <description>ADC group regular end of sampling interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EOCIE</name>
+              <description>ADC group regular end of unitary conversion interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EOSEQIE</name>
+              <description>ADC group regular end of sequence conversions interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OVRIE</name>
+              <description>ADC group regular overrun interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>AWDIE</name>
+              <description>ADC analog watchdog interrupt</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>ADC control register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>ADEN</name>
+              <description>ADC enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADDIS</name>
+              <description>ADC enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADSTART</name>
+              <description>ADC group regular conversion start</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADSTP</name>
+              <description>ADC group regular conversion stop</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>VREF_BUFFERE</name>
+              <description>desc VREF_BUFFERE</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>VERBUFF_SEL</name>
+              <description>desc VERBUFF_SEL</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>ADCAL</name>
+              <description>ADC group regular conversion calibration</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>ADC configuration register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>SCANDIR</name>
+              <description>Scan sequence direction</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>ADC data resolution</description>
+              <bitRange>[4:3]</bitRange>
+            </field>
+            <field>
+              <name>ALIGN</name>
+              <description>ADC data alignement</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>EXTSEL</name>
+              <description>ADC group regular external trigger source</description>
+              <bitRange>[8:6]</bitRange>
+            </field>
+            <field>
+              <name>EXTEN</name>
+              <description>ADC group regular external trigger polarity</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>OVRMOD</name>
+              <description>ADC group regular overrun configuration</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CONT</name>
+              <description>ADC group regular continuous conversion mode</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>WAIT</name>
+              <description>Wait conversion mode</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>DISCEN</name>
+              <description>ADC group regular sequencer discontinuous mode</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>AWDSGL</name>
+              <description>ADC analog watchdog monitoring a single channel or all channels</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>AWDEN</name>
+              <description>ADC analog watchdog enable on scope ADC group regular</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>AWDCH</name>
+              <description>ADC analog watchdog monitored channel selection</description>
+              <bitRange>[29:26]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>ADC configuration register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>CKMODE</name>
+              <description>ADC clock mode</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMPR</name>
+          <displayName>SMPR</displayName>
+          <description>ADC sampling time register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>SMP</name>
+              <description>Sampling time selection</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TR</name>
+          <displayName>TR</displayName>
+          <description>ADC analog watchdog 1 threshold register</description>
+          <addressOffset>0x20</addressOffset>
+          <resetValue>0xFFF0000</resetValue>
+          <fields>
+            <field>
+              <name>LT</name>
+              <description>ADC analog watchdog threshold low</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>HT</name>
+              <description>ADC analog watchdog threshold high</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSELR</name>
+          <displayName>CHSELR</displayName>
+          <description>ADC group regular sequencer register</description>
+          <addressOffset>0x28</addressOffset>
+          <resetValue>0xFFF0000</resetValue>
+          <fields>
+            <field>
+              <name>CHSEL0</name>
+              <description>Channel-0 selection</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL1</name>
+              <description>Channel-1 selection</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL2</name>
+              <description>Channel-2 selection</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL3</name>
+              <description>Channel-3 selection</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL4</name>
+              <description>Channel-4 selection</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL5</name>
+              <description>Channel-5 selection</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL6</name>
+              <description>Channel-6 selection</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL7</name>
+              <description>Channel-7 selection</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL8</name>
+              <description>Channel-8 selection</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CHSEL9</name>
+              <description>Channel-9 selection</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>ADC group regular data register</description>
+          <addressOffset>0x40</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>ADC group regular conversion data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCSR</name>
+          <displayName>CCSR</displayName>
+          <description>ADC calibration configuration and status register</description>
+          <addressOffset>0x44</addressOffset>
+          <fields>
+            <field>
+              <name>CALSEL</name>
+              <description>Calibration contents selection</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CALSMP</name>
+              <description>Calibration sample time selection</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>CALBYP</name>
+              <description>desc CALBYP</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CALSET</name>
+              <description>Calibration factor selection</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>OFFSUC</name>
+              <description>desc OFFSUC</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>CALSUC</name>
+              <description>desc CALSUC</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>CALON</name>
+              <description>Calibration flag</description>
+              <bitRange>[31:31]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <displayName>CCR</displayName>
+          <description>ADC common configuration register</description>
+          <addressOffset>0x308</addressOffset>
+          <fields>
+            <field>
+              <name>VREFEN</name>
+              <description>VREFINT enable</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature sensor enable</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <description>CRC calculation unit</description>
+      <groupName>CRC</groupName>
+      <baseAddress>0x40023000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data Register</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>Independent Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>IDR</name>
+              <description>Independent Data register</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control register</description>
+          <addressOffset>0x8</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>RESET</name>
+              <description>Reset bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBGMCU</name>
+      <description>Debug support</description>
+      <groupName>DBGMCU</groupName>
+      <baseAddress>0x40015800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>IDCODE</name>
+          <displayName>IDCODE</displayName>
+          <description>MCU Device ID Code Register</description>
+          <addressOffset>0x0</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>REV_ID</name>
+              <description>REV_ID</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Debug MCU Configuration Register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_STOP</name>
+              <description>Debug Stop Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ1</name>
+          <displayName>APB_FZ1</displayName>
+          <description>APB Freeze Register1</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_LPTIM_STOP</name>
+              <description>Debug LPTIM stopped when Core ishalted</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ2</name>
+          <displayName>APB_FZ2</displayName>
+          <description>APB Freeze Register2</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_TIMER1_STOP</name>
+              <description>Debug Timer 1 stopped when Core ishalted</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>DBG_TIM14_STOP</name>
+              <description>Debug TIM 14 stopped whenCore is halted</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>External interrupt/event controller</description>
+      <groupName>EXTI</groupName>
+      <baseAddress>0x40021800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EXTI0_1</name>
+        <description>EXTI Line 0 and 1 Interrupt</description>
+        <value>5</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI2_3</name>
+        <description>EXTI Line 2 and 3 Interrupt</description>
+        <value>6</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI4_15</name>
+        <description>EXTI Line 4 to 15 Interrupt</description>
+        <value>7</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>RTSR</name>
+          <displayName>RTSR</displayName>
+          <description>EXTI rising trigger selection register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>RT0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>RT1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>RT2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>RT3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>RT4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>RT5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>RT6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>RT7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>RT17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>RT18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTSR</name>
+          <displayName>FTSR</displayName>
+          <description>EXTI falling trigger selection register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>FT0</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FT1</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FT2</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FT3</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>FT4</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>FT5</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>FT6</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>FT7</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>FT17</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>FT18</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIER</name>
+          <displayName>SWIER</displayName>
+          <description>EXTI software interrupt event register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>SWI0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SWI1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SWI2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SWI3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SWI4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SWI5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SWI6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SWI7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SWI17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SWI18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>EXTI pending register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PR0</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PR1</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PR2</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PR3</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PR4</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PR5</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PR6</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PR7</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>PR17</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PR18</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <displayName>EXTICR1</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x60</addressOffset>
+          <fields>
+            <field>
+              <name>EXTI0</name>
+              <description>GPIO port selection</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>GPIO port selection</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>GPIO port selection</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+            <field>
+              <name>EXTI3</name>
+              <description>GPIO port selection</description>
+              <bitRange>[25:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <displayName>EXTICR2</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x64</addressOffset>
+          <fields>
+            <field>
+              <name>EXTI4</name>
+              <description>GPIO port selection</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>GPIO port selection</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>GPIO port selection</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>EXTI7</name>
+              <description>GPIO port selection</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <displayName>IMR</displayName>
+          <description>EXTI CPU wakeup with interrupt mask register</description>
+          <addressOffset>0x80</addressOffset>
+          <resetValue>0xFFF80000</resetValue>
+          <fields>
+            <field>
+              <name>IM0</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>IM1</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>IM2</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>IM3</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>IM4</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>IM5</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>IM6</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>IM7</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>IM17</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>IM18</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>IM29</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMR</name>
+          <displayName>EMR</displayName>
+          <description>EXTI CPU wakeup with event mask register</description>
+          <addressOffset>0x84</addressOffset>
+          <fields>
+            <field>
+              <name>EM0</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>EM1</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EM2</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EM3</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>EM4</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>EM5</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>EM6</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>EM7</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>EM17</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>EM18</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>EM29</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>Flash</description>
+      <groupName>Flash</groupName>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>FLASH global Interrupt</description>
+        <value>3</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ACR</name>
+          <displayName>ACR</displayName>
+          <description>Access control register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0x600</resetValue>
+          <fields>
+            <field>
+              <name>LATENCY</name>
+              <description>Latency</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>KEYR</name>
+          <displayName>KEYR</displayName>
+          <description>Flash key register</description>
+          <addressOffset>0x8</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Flash key</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTKEYR</name>
+          <displayName>OPTKEYR</displayName>
+          <description>Option byte key register</description>
+          <addressOffset>0xC</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Option byte key</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>WRPERR</name>
+              <description>Write protected error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OPTVERR</name>
+              <description>Option and Engineering bits loading validity error</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Flash control register</description>
+          <addressOffset>0x14</addressOffset>
+          <resetValue>0xC0000000</resetValue>
+          <fields>
+            <field>
+              <name>PG</name>
+              <description>Programming</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Page erase</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass erase</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SER</name>
+              <description>Sector erase</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OPTSTRT</name>
+              <description>Option byte program start</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PGSTRT</name>
+              <description>Flash main memory program start</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt enable</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>OBL_LAUNCH</name>
+              <description>Force the option byte loading</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>OPTLOCK</name>
+              <description>Options Lock</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>FLASH_CR Lock</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTR</name>
+          <displayName>OPTR</displayName>
+          <description>Flash option register</description>
+          <addressOffset>0x20</addressOffset>
+          <resetValue>0x4F55B0AA</resetValue>
+          <fields>
+            <field>
+              <name>BOREN</name>
+              <description>BOR reset Level</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>BORF_LEV</name>
+              <description>These bits contain the VDD supply level threshold that activates the reset</description>
+              <bitRange>[11:9]</bitRange>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <description>Independent watchdog selection</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SWD_MODE</name>
+              <description>SWD_MODE</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>NRST_MODE</name>
+              <description>NRST_MODE</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDKR</name>
+          <displayName>SDKR</displayName>
+          <description>Flash SDK address register</description>
+          <addressOffset>0x24</addressOffset>
+          <resetValue>0xFFE0001F</resetValue>
+          <fields>
+            <field>
+              <name>SDK_STRT</name>
+              <description>SDK area start address</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>SDK_END</name>
+              <description>SDK area end address</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BTCR</name>
+          <displayName>BTCR</displayName>
+          <description>FLASH boot control register</description>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>BOOT_SIZE</name>
+              <description>desc BOOT_SIZE</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+            <field>
+              <name>BOOT0</name>
+              <description>desc BOOT0</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>NBOOT1</name>
+              <description>desc NBOOT1</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRPR</name>
+          <displayName>WRPR</displayName>
+          <description>Flash WRP address register</description>
+          <addressOffset>0x2C</addressOffset>
+          <resetValue>0xFFFF</resetValue>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <description>WRP address</description>
+              <bitRange>[5:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STCR</name>
+          <displayName>STCR</displayName>
+          <description>Flash sleep time config register</description>
+          <addressOffset>0x90</addressOffset>
+          <resetValue>0x6400</resetValue>
+          <fields>
+            <field>
+              <name>SLEEP_EN</name>
+              <description>FLash sleep enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SLEEP_TIME</name>
+              <description>FLash sleep time configuration(counter based on HSI_10M)</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS0</name>
+          <displayName>TS0</displayName>
+          <description>Flash TS0 register</description>
+          <addressOffset>0x100</addressOffset>
+          <resetValue>0xB4</resetValue>
+          <fields>
+            <field>
+              <name>TS0</name>
+              <description>FLash TS0 register</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS1</name>
+          <displayName>TS1</displayName>
+          <description>Flash TS1 register</description>
+          <addressOffset>0x104</addressOffset>
+          <resetValue>0x1B0</resetValue>
+          <fields>
+            <field>
+              <name>TS1</name>
+              <description>FLash TS1 register</description>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS2P</name>
+          <displayName>TS2P</displayName>
+          <description>Flash TS2P register</description>
+          <addressOffset>0x108</addressOffset>
+          <resetValue>0xB4</resetValue>
+          <fields>
+            <field>
+              <name>TS2P</name>
+              <description>FLash TS2P register</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TPS3</name>
+          <displayName>TPS3</displayName>
+          <description>Flash TPS3 register</description>
+          <addressOffset>0x10C</addressOffset>
+          <resetValue>0x6C0</resetValue>
+          <fields>
+            <field>
+              <name>TPS3</name>
+              <description>FLash TPS3 register</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS3</name>
+          <displayName>TS3</displayName>
+          <description>Flash TS3 register</description>
+          <addressOffset>0x110</addressOffset>
+          <resetValue>0xB4</resetValue>
+          <fields>
+            <field>
+              <name>TS3</name>
+              <description>FLash TS3 register</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERTPE</name>
+          <displayName>PERTPE</displayName>
+          <description>Flash PERTPE register</description>
+          <addressOffset>0x114</addressOffset>
+          <resetValue>0x14820</resetValue>
+          <fields>
+            <field>
+              <name>PERTPE</name>
+              <description>FLash PERTPE register</description>
+              <bitRange>[17:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMERTPE</name>
+          <displayName>SMERTPE</displayName>
+          <description>Flash SMERTPE register</description>
+          <addressOffset>0x118</addressOffset>
+          <resetValue>0x14820</resetValue>
+          <fields>
+            <field>
+              <name>SMERTPE</name>
+              <description>FLash SMERTPE register</description>
+              <bitRange>[17:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGTPE</name>
+          <displayName>PRGTPE</displayName>
+          <description>Flash PRGTPE register</description>
+          <addressOffset>0x11C</addressOffset>
+          <resetValue>0x5DC0</resetValue>
+          <fields>
+            <field>
+              <name>PRGTPE</name>
+              <description>FLash PRGTPE register</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRETPE</name>
+          <displayName>PRETPE</displayName>
+          <description>Flash PRETPE register</description>
+          <addressOffset>0x120</addressOffset>
+          <resetValue>0x12C0</resetValue>
+          <fields>
+            <field>
+              <name>PRETPE</name>
+              <description>FLash PRETPE register</description>
+              <bitRange>[13:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>MODE7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>OT2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OT3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OT4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OT5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>OT6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>OT7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <resetValue>0xC000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>PUPD2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>PUPD3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>PUPD4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>PUPD5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>PUPD6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>PUPD7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ID2</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ID3</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ID4</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ID5</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>ID6</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>ID7</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>OD2</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OD3</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OD4</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OD5</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>OD6</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>OD7</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL2</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL3</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL4</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL5</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL6</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL7</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port Reset bit</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port Reset bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port Reset bit</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port Reset bit</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port Reset bit</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Port Reset bit</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x50000400</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>GPIOC</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <resetValue>0xC000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <groupName>IWDG</groupName>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>KR</name>
+          <displayName>KR</displayName>
+          <description>Key register (IWDG_KR)</description>
+          <addressOffset>0x0</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>Prescaler register (IWDG_PR)</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLR</name>
+          <displayName>RLR</displayName>
+          <description>Reload register (IWDG_RLR)</description>
+          <addressOffset>0x8</addressOffset>
+          <resetValue>0xFFF</resetValue>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload value</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value update</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value update</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>LPTIM1</name>
+      <description>Low power timer</description>
+      <groupName>LPTIM1</groupName>
+      <baseAddress>0x40007C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>LPTIM1_DAC</name>
+        <description>LPTIM1, DAC global Interrupts</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>Interrupt and Status Register</description>
+          <addressOffset>0x0</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>ARRM</name>
+              <description>Autoreload match</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ARROK</name>
+              <description>Autoreload match update OK</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <displayName>ICR</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x4</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>ARRMCF</name>
+              <description>Autoreload match Clear Flag</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ARROKCF</name>
+              <description>Autoreload match update OK Clear Flag</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>Interrupt Enable Register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>ARRMIE</name>
+              <description>Autoreload matchInterrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ARROKIE</name>
+              <description>Autoreload match update OK Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Configuration Register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PRESC</name>
+              <description>Clock prescaler</description>
+              <bitRange>[11:9]</bitRange>
+            </field>
+            <field>
+              <name>PRELOAD</name>
+              <description>Registers update mode</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control Register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>LPTIM Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SNGSTRT</name>
+              <description>LPTIM start in single mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CNTSTRT</name>
+              <description>CNTSTRT</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>COUNTRST</name>
+              <description>Reset counter</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>RSTARE</name>
+              <description>Reset after read enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <displayName>ARR</displayName>
+          <description>Autoreload Register</description>
+          <addressOffset>0x18</addressOffset>
+          <resetValue>0x1</resetValue>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>Auto reload value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>Counter Register</description>
+          <addressOffset>0x1C</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>Counter value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <groupName>PWR</groupName>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Power control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0x30000</resetValue>
+          <fields>
+            <field>
+              <name>BIAS_CR</name>
+              <description>MR Bias current</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>BIAS_CR_SEL</name>
+              <description>MR Bias current selection</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>DBP</name>
+              <description>Disable backup domain write protection</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>VOS</name>
+              <description>Voltage scaling range selection</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>MRRDY_TIME</name>
+              <description>Time selection wakeup from LP to VR</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>FLS_SLPTIME</name>
+              <description>Flash wait time after wakeup from the stop mode</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>LPR</name>
+              <description>Low-power run</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+            <field>
+              <name>SRAM_RETV</name>
+              <description>SRAM retention voltage control</description>
+              <bitRange>[18:16]</bitRange>
+            </field>
+            <field>
+              <name>HSION_CTRL</name>
+              <description>HSI open time control</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <displayName>CR2</displayName>
+          <description>Power control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <resetValue>0x500</resetValue>
+          <fields>
+            <field>
+              <name>FLTEN</name>
+              <description>Digital filter enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>FLT_TIME</name>
+              <description>Digital filter time configuration</description>
+              <bitRange>[11:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <groupName>RCC</groupName>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RCC</name>
+        <description>RCC global Interrupt</description>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0x100</resetValue>
+          <fields>
+            <field>
+              <name>HSION</name>
+              <description>HSI16 clock enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>HSI16 clock ready flag</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>HSIDIV</name>
+              <description>HSI16 clock division factor</description>
+              <bitRange>[13:11]</bitRange>
+            </field>
+            <field>
+              <name>HSEEN</name>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICSCR</name>
+          <displayName>ICSCR</displayName>
+          <description>Internal clock sources calibration register</description>
+          <addressOffset>0x4</addressOffset>
+          <resetValue>0x10000000</resetValue>
+          <fields>
+            <field>
+              <name>HSI_TRIM</name>
+              <description>HSI clock trimming</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+            <field>
+              <name>HSI_FS</name>
+              <description>HSI frequency selection</description>
+              <bitRange>[15:13]</bitRange>
+            </field>
+            <field>
+              <name>LSI_TRIM</name>
+              <description>LSI clock trimming</description>
+              <bitRange>[24:16]</bitRange>
+            </field>
+            <field>
+              <name>LSI_STARTUP</name>
+              <description>LSI startup time</description>
+              <bitRange>[27:26]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Clock configuration register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>SW</name>
+              <description>System clock switch</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+            <field>
+              <name>SWS</name>
+              <description>System clock switch status</description>
+              <bitRange>[5:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>HPRE</name>
+              <description>AHB prescaler</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>PPRE</name>
+              <description>APB prescaler</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>MCOSEL</name>
+              <description>Microcontroller clock output</description>
+              <bitRange>[26:24]</bitRange>
+            </field>
+            <field>
+              <name>MCOPRE</name>
+              <description>Microcontroller clock output prescaler</description>
+              <bitRange>[30:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECSCR</name>
+          <displayName>ECSCR</displayName>
+          <description>External clock source control register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>LSE_DRIVER</name>
+              <description>desc LSE_DRIVER</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+            <field>
+              <name>LSE_STARTUP</name>
+              <description>desc LSE_STARTUP</description>
+              <bitRange>[21:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIER</name>
+          <displayName>CIER</displayName>
+          <description>Clock interrupt enable register</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>LSIRDYIE</name>
+              <description>LSI ready interrupt enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDYIE</name>
+              <description>LSE ready interrupt enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDYIE</name>
+              <description>HSI ready interrupt enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIFR</name>
+          <displayName>CIFR</displayName>
+          <description>Clock interrupt flag register</description>
+          <addressOffset>0x1C</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LSIRDYF</name>
+              <description>LSI ready interrupt flag</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDYF</name>
+              <description>LSE ready interrupt flag</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDYF</name>
+              <description>HSI ready interrupt flag</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSF</name>
+              <description>LSE clock secure system interrupt flag</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CICR</name>
+          <displayName>CICR</displayName>
+          <description>Clock interrupt clear register</description>
+          <addressOffset>0x20</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>LSIRDYC</name>
+              <description>LSI ready interrupt clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDYC</name>
+              <description>LSE ready interrupt clear</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDYC</name>
+              <description>HSI ready interrupt clear</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSC</name>
+              <description>LSE clock secure system interrupt flag clear</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPRSTR</name>
+          <displayName>IOPRSTR</displayName>
+          <description>GPIO reset register</description>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>GPIOARST</name>
+              <description>I/O port A reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>GPIOBRST</name>
+              <description>I/O port B reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>GPIOCRST</name>
+              <description>I/O port C reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBRSTR</name>
+          <displayName>AHBRSTR</displayName>
+          <description>AHB peripheral reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>FLASHRST</name>
+              <description>FLASH reset</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CRCRST</name>
+              <description>CRC reset</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR1</name>
+          <displayName>APBRSTR1</displayName>
+          <description>APB peripheral reset register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>DBGRST</name>
+              <description>Debug support reset</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>PWRRST</name>
+              <description>Power interface reset</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>LPTIMRST</name>
+              <description>Low Power Timer reset</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR2</name>
+          <displayName>APBRSTR2</displayName>
+          <description>APB peripheral reset register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCFGRST</name>
+              <description>SYSCFG reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIM1RST</name>
+              <description>TIM1 timer reset</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIM14RST</name>
+              <description>TIM14 reset</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>ADCRST</name>
+              <description>ADC reset</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPENR</name>
+          <displayName>IOPENR</displayName>
+          <description>GPIO clock enable register</description>
+          <addressOffset>0x34</addressOffset>
+          <fields>
+            <field>
+              <name>GPIOAEN</name>
+              <description>I/O port A clock enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>GPIOBEN</name>
+              <description>I/O port B clock enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>GPIOCEN</name>
+              <description>I/O port C clock enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBENR</name>
+          <displayName>AHBENR</displayName>
+          <description>AHB peripheral clock enable register</description>
+          <addressOffset>0x38</addressOffset>
+          <fields>
+            <field>
+              <name>FLASHEN</name>
+              <description>Flash memory interface clock enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SRAMEN</name>
+              <description>SRAM memory interface clock enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CRCEN</name>
+              <description>CRC clock enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR1</name>
+          <displayName>APBENR1</displayName>
+          <description>APB peripheral clock enable register 1</description>
+          <addressOffset>0x3C</addressOffset>
+          <fields>
+            <field>
+              <name>DBGEN</name>
+              <description>Debug support clock enable</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>PWREN</name>
+              <description>Power interface clock enable</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>LPTIMEN</name>
+              <description>LPTIM clock enable</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR2</name>
+          <displayName>APBENR2</displayName>
+          <description>APB peripheral clock enable register 2</description>
+          <addressOffset>0x40</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCFGEN</name>
+              <description>SYSCFG and VREFBUF clock enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>TIM1 timer clock enable</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIM14EN</name>
+              <description>TIM14 clock enable</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>ADCEN</name>
+              <description>ADC clock enable</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCIPR</name>
+          <displayName>CCIPR</displayName>
+          <description>Peripherals independent clock configuration register</description>
+          <addressOffset>0x54</addressOffset>
+          <fields>
+            <field>
+              <name>LPTIM1SEL</name>
+              <description>LPTIM1 clock source selection</description>
+              <bitRange>[19:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDCR</name>
+          <displayName>BDCR</displayName>
+          <description>RTC domain control register</description>
+          <addressOffset>0x5C</addressOffset>
+          <fields>
+            <field>
+              <name>LSEON</name>
+              <description>LSE oscillator enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDY</name>
+              <description>LSE oscillator ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LSEBYP</name>
+              <description>LSE oscillator bypass</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSON</name>
+              <description>LSE CSS enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSD</name>
+              <description>LSE CSS detect</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>LSCOEN</name>
+              <description>Low-speed clock output (LSCO) enable</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>LSCOSEL</name>
+              <description>Low-speed clock output selection</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>Control/status register</description>
+          <addressOffset>0x60</addressOffset>
+          <fields>
+            <field>
+              <name>LSION</name>
+              <description>LSI oscillator enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSIRDY</name>
+              <description>LSI oscillator ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PINRST_FLTDIS</name>
+              <description>desc PINRST_FLTDIS</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>RMVF</name>
+              <description>Remove reset flags</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>OBLRSTF</name>
+              <description>Option byte loader reset flag</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>Pin reset flag</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>PWRRSTF</name>
+              <description>BOR or POR/PDR flag</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Software reset flag</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>Independent window watchdog reset flag</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCFG</name>
+      <description>System configuration controller</description>
+      <groupName>SYSCFG</groupName>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>SYSCFG configuration register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>MEM_MODE</name>
+              <description>Memory mapping selection bits</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>SYSCFG configuration register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>LOCKUP_LOCK</name>
+              <description>Cortex-M0+ LOCKUP bit enable bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ETR_SRC_TIM1</name>
+              <description>TIM1 ETR source selection</description>
+              <bitRange>[10:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIO_ENS</name>
+          <description>desc GPIO_ENS</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>PA_ENS</name>
+              <description>desc PA_ENS</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>PB_ENS</name>
+              <description>desc PB_ENS</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+            <field>
+              <name>PC_ENS</name>
+              <description>desc PC_ENS</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK_UP_TRG_COM</name>
+        <description>TIM1 Break, Update, Trigger and Commutation Interrupt</description>
+        <value>13</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Interrupt</description>
+        <value>14</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>desc DIR</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CMS</name>
+              <description>desc CMS</description>
+              <bitRange>[6:5]</bitRange>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <resetMask>0xF8</resetMask>
+          <fields>
+            <field>
+              <name>CCPC</name>
+              <description>desc CCPC</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CCUS</name>
+              <description>desc CCUS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>MMS</name>
+              <description>desc MMS</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>TI1S</name>
+              <description>desc TI1S</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>OIS1</name>
+              <description>desc OIS1</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>OIS1N</name>
+              <description>desc OIS1N</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>OIS2</name>
+              <description>desc OIS2</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OIS2N</name>
+              <description>desc OIS2N</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OIS3</name>
+              <description>desc OIS3</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>OIS3N</name>
+              <description>desc OIS3N</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>desc OIS4</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCR</name>
+          <description>desc SMCR</description>
+          <addressOffset>0x8</addressOffset>
+          <resetMask>0xFFF7</resetMask>
+          <fields>
+            <field>
+              <name>SMS</name>
+              <description>desc SMS</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+            <field>
+              <name>OCCS</name>
+              <description>desc OCCS</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TS</name>
+              <description>desc TS</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>MSM</name>
+              <description>desc MSM</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>ETF</name>
+              <description>desc ETF</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ETPS</name>
+              <description>desc ETPS</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>ECE</name>
+              <description>desc ECE</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>desc ETP</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC2IE</name>
+              <description>desc CC2IE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC3IE</name>
+              <description>desc CC3IE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC4IE</name>
+              <description>desc CC4IE</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMIE</name>
+              <description>desc COMIE</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>desc TIE</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BIE</name>
+              <description>desc BIE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC2IF</name>
+              <description>desc CC2IF</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC3IF</name>
+              <description>desc CC3IF</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC4IF</name>
+              <description>desc CC4IF</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMIF</name>
+              <description>desc COMIF</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIF</name>
+              <description>desc TIF</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BIF</name>
+              <description>desc BIF</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>desc CC2OF</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CC3OF</name>
+              <description>desc CC3OF</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>desc CC4OF</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>IC2IR</name>
+              <description>desc IC2IR</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>IC3IR</name>
+              <description>desc IC3IR</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>IC4IR</name>
+              <description>desc IC3IR</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>IC2IF</name>
+              <description>desc IC2IF</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>IC3IF</name>
+              <description>desc IC3IF</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>IC4IF</name>
+              <description>desc IC3IF</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <access>write-only</access>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture 1 Generation</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC2G</name>
+              <description>desc CC2G</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC3G</name>
+              <description>desc CC3G</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC4G</name>
+              <description>desc CC4G</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>COMG</name>
+              <description>desc COMG</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TG</name>
+              <description>desc TG</description>
+              <bitRange>[6:6]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>desc BG</description>
+              <bitRange>[7:7]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1FE</name>
+              <description>desc OC1FE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>OC1CE</name>
+              <description>desc OC1CE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OC2FE</name>
+              <description>desc OC2FE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OC2PE</name>
+              <description>desc OC2PE</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OC2M</name>
+              <description>desc OC2M</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>desc OC2CE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>IC2PSC</name>
+              <description>desc IC2PSC</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>desc IC2F</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_OUTPUT</name>
+          <description>desc CCMR2:OUTPUT</description>
+          <addressOffset>0x1C</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC3FE</name>
+              <description>desc OC3FE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OC3PE</name>
+              <description>desc OC3PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC3M</name>
+              <description>desc OC3M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>OC3CE</name>
+              <description>desc OC3CE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OC4FE</name>
+              <description>desc OC4FE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OC4PE</name>
+              <description>desc OC4PE</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OC4M</name>
+              <description>desc OC4M</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>desc OC4CE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_INPUT</name>
+          <description>desc CCMR2:INPUT</description>
+          <alternateRegister>CCMR2_OUTPUT</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC3PSC</name>
+              <description>desc IC3PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC3F</name>
+              <description>desc IC3F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>IC4PSC</name>
+              <description>desc IC4PSC</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>desc IC4F</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1NE</name>
+              <description>desc CC1NE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC2E</name>
+              <description>desc CC2E</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>desc CC2P</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CC2NE</name>
+              <description>desc CC2NE</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CC2NP</name>
+              <description>desc CC2NP</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC3E</name>
+              <description>desc CC3E</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CC3P</name>
+              <description>desc CC3P</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CC3NE</name>
+              <description>desc CC3NE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CC3NP</name>
+              <description>desc CC3NP</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CC4E</name>
+              <description>desc CC4E</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>desc CC4P</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCR</name>
+          <description>desc RCR</description>
+          <addressOffset>0x30</addressOffset>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>REP</name>
+              <description>desc REP</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR2</name>
+          <description>desc CCR2</description>
+          <addressOffset>0x38</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR2</name>
+              <description>desc CCR2</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR3</name>
+          <description>desc CCR3</description>
+          <addressOffset>0x3C</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR3</name>
+              <description>desc CCR3</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR4</name>
+          <description>desc CCR4</description>
+          <addressOffset>0x40</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR4</name>
+              <description>desc CCR4</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <description>desc BDTR</description>
+          <addressOffset>0x44</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>DTG</name>
+              <description>desc DTG</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>desc LOCK</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OSSI</name>
+              <description>desc OSSI</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OSSR</name>
+              <description>desc OSSR</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>BKE</name>
+              <description>desc BKE</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>BKP</name>
+              <description>desc BKP</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>AOE</name>
+              <description>desc AOE</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>desc MOE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM14</name>
+      <description>General purpose timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40002000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM14</name>
+        <description>TIM14 global Interrupt</description>
+        <value>19</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <access>write-only</access>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture Generation</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OR</name>
+          <description>desc OR</description>
+          <addressOffset>0x50</addressOffset>
+          <fields>
+            <field>
+              <name>TI1_RMP</name>
+              <description>desc TI1_RMP</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/MS32C001Bxx.svd
+++ b/svd/MS32C001Bxx.svd
@@ -1,0 +1,4131 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>MS</vendor>
+  <vendorID>MS</vendorID>
+  <name>ms32c001bxx</name>
+  <series>MS32C</series>
+  <version>1.0.0</version>
+  <description>Arm 32-bit Cortex-M0+ Microcontroller based device, CPU clock up to 48 MHz.</description>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x0</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>ADC</name>
+      <description>Analog to Digital Converter</description>
+      <baseAddress>0x40012400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC_COMP</name>
+        <description>ADC and COMP Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <description>ADC interrupt and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>EOSMP</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EOC</name>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EOSEQ</name>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OVR</name>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>AWD</name>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>EOH</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <description>ADC interrupt enable register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>EOSMPIE</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EOCIE</name>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EOSEQIE</name>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OVRIE</name>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>AWDIE</name>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>EOHIE</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <description>ADC control register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>ADEN</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADDIS</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADSTART</name>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADSTP</name>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>RSTCAL</name>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>ADCAL_START</name>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>ADCAL</name>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR1</name>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>RES</name>
+              <bitRange>[4:3]</bitRange>
+            </field>
+            <field>
+              <name>ALIGN</name>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>EXTSEL</name>
+              <bitRange>[8:6]</bitRange>
+            </field>
+            <field>
+              <name>EXTEN</name>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>OVRMOD</name>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CONT</name>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>WAIT</name>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>DISCEN</name>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>CALNUM</name>
+              <bitRange>[19:17]</bitRange>
+            </field>
+            <field>
+              <name>AWDSGL</name>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>AWDEN</name>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>AWDCH</name>
+              <bitRange>[29:26]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <description>ADC configuration register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>CKMODE</name>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMPR</name>
+          <description>ADC sampling time register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>SMP</name>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TR</name>
+          <description>ADC analog watchdog 1 threshold register</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>LT1</name>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>HT1</name>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SQR1</name>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>L</name>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>SQ1</name>
+              <bitRange>[9:6]</bitRange>
+            </field>
+            <field>
+              <name>SQ2</name>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>SQ3</name>
+              <bitRange>[21:18]</bitRange>
+            </field>
+            <field>
+              <name>SQ4</name>
+              <bitRange>[27:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SQR2</name>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>SQ5</name>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>SQ6</name>
+              <bitRange>[9:6]</bitRange>
+            </field>
+            <field>
+              <name>SQ7</name>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>SQ8</name>
+              <bitRange>[21:18]</bitRange>
+            </field>
+            <field>
+              <name>SQ9</name>
+              <bitRange>[27:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SQR3</name>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>SQ10</name>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>SQ11</name>
+              <bitRange>[9:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <bitRange>[15:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALFACT</name>
+          <addressOffset>0x44</addressOffset>
+          <fields>
+            <field>
+              <name>WCALFACT</name>
+              <bitRange>[8:0]</bitRange>
+            </field>
+            <field>
+              <name>FACTSEL</name>
+              <bitRange>[13:9]</bitRange>
+            </field>
+            <field>
+              <name>WRVLD</name>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>RDVLD</name>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>CAPSUC</name>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>RCALFACT</name>
+              <bitRange>[31:23]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <description>ADC common configuration register</description>
+          <addressOffset>0x48</addressOffset>
+          <fields>
+            <field>
+              <name>VREFEN</name>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>TSEN</name>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>VREFSEL</name>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>PWRMODE</name>
+              <bitRange>[27:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBGMCU</name>
+      <description>Debug support</description>
+      <baseAddress>0x40015800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DBG_IDCODE</name>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_ID</name>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <description>Debug MCU Configuration Register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_SLEEP</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>DBG_STOP</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBG_APB_FZ1</name>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_IWDG_STOP</name>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>DBG_LPTIM1_STOP</name>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBG_APB_FZ2</name>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>DBG_TIM1_STOP</name>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>DBG_TIM14_STOP</name>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>DBG_PWM1_STOP</name>
+              <bitRange>[19:19]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>External interrupt/event controller</description>
+      <baseAddress>0x40021800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EXTI0_1</name>
+        <description>EXTI Line 0 and 1 Interrupt</description>
+        <value>5</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI2_3</name>
+        <description>EXTI Line 2 and 3 Interrupt</description>
+        <value>6</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI4_15</name>
+        <description>EXTI Line 4 to 15 Interrupt</description>
+        <value>7</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>RTSR</name>
+          <description>EXTI rising trigger selection register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>RT0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>RT1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>RT2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>RT3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>RT4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>RT5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>RT6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>RT7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>RT16</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>RT17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>RT18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTSR</name>
+          <description>EXTI falling trigger selection register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>FT0</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FT1</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FT2</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FT3</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>FT4</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>FT5</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>FT6</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>FT7</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>FT16</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>FT17</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>FT18</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIER</name>
+          <description>EXTI software interrupt event register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>SWI0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SWI1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SWI2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SWI3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SWI4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SWI5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SWI6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SWI7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SWI16</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[16:16]</bitRange>
+            </field>            
+            <field>
+              <name>SWI17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SWI18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <description>EXTI pending register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PR0</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PR1</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PR2</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PR3</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PR4</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PR5</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PR6</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PR7</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>PR16</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[16:16]</bitRange>
+            </field>            
+            <field>
+              <name>PR17</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PR18</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x60</addressOffset>
+          <fields>
+            <field>
+              <name>EXTI0</name>
+              <description>GPIO port selection</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>GPIO port selection</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>GPIO port selection</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+            <field>
+              <name>EXTI3</name>
+              <description>GPIO port selection</description>
+              <bitRange>[25:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x64</addressOffset>
+          <fields>
+            <field>
+              <name>EXTI4</name>
+              <description>GPIO port selection</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>GPIO port selection</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>GPIO port selection</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>EXTI7</name>
+              <description>GPIO port selection</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <description>EXTI CPU wakeup with interrupt mask register</description>
+          <addressOffset>0x80</addressOffset>
+          <fields>
+            <field>
+              <name>IM0</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>IM1</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>IM2</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>IM3</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>IM4</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>IM5</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>IM6</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>IM7</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>IM16</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>IM29</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMR</name>
+          <description>EXTI CPU wakeup with event mask register</description>
+          <addressOffset>0x84</addressOffset>
+          <fields>
+            <field>
+              <name>EM0</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>EM1</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EM2</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EM3</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>EM4</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>EM5</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>EM6</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>EM7</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>EM16</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[16:16]</bitRange>
+            </field>            
+            <field>
+              <name>EM17</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>EM18</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>EM29</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>Flash</description>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>FLASH global Interrupt</description>
+        <value>3</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>KEYR</name>
+          <description>Flash key register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Flash CR key</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTKEYR</name>
+          <description>Option byte key register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Flash Option key</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>Status register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>WRPERR</name>
+              <description>Write protection error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OPTVERR</name>
+              <description>Option and trimming bits loading validity error</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitRange>[16:16]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <description>Flash control register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>PG</name>
+              <description>Page Program</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Page Erase</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass Erase</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SER</name>
+              <description>Sector Erase</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OPTSTRT</name>
+              <description>Option bytes Programming Start</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PGSTRT</name>
+              <description>Programming Start</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt enable</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>OBL_LAUNCH</name>
+              <description>Force the option bytes loading</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>OPTLOCK</name>
+              <description>Option Lock</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>Lock</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTR</name>
+          <description>Flash option register</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>RDP</name>
+              <description>Read Protection</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>BOR_EN</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>BOR_LEV</name>
+              <bitRange>[11:9]</bitRange>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>NRST_MODE</name>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>IWDG_STOP</name>
+              <description>IWDG Software Enable</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDKR</name>
+          <description>Flash SDK address register</description>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>SDK_STRT</name>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>SDK_END</name>
+              <bitRange>[11:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRPR</name>
+          <description>Flash WRP address register</description>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STCR</name>
+          <description>Flash sleep time config register</description>
+          <addressOffset>0x90</addressOffset>
+          <fields>
+            <field>
+              <name>SLEEP_EN</name>
+              <description>Sleep enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS0</name>
+          <description>Flash TS0 register</description>
+          <addressOffset>0x100</addressOffset>
+          <fields>
+            <field>
+              <name>TS0</name>
+              <description>TS0</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS1</name>
+          <description>Flash TS1 register</description>
+          <addressOffset>0x104</addressOffset>
+          <fields>
+            <field>
+              <name>TS1</name>
+              <description>TS1</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS2P</name>
+          <description>Flash TS2P register</description>
+          <addressOffset>0x108</addressOffset>
+          <fields>
+            <field>
+              <name>TS2P</name>
+              <description>TS2P</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TPS3</name>
+          <description>Flash TPS3 register</description>
+          <addressOffset>0x10C</addressOffset>
+          <fields>
+            <field>
+              <name>TPS3</name>
+              <description>TPS3</description>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS3</name>
+          <description>Flash TS3 register</description>
+          <addressOffset>0x110</addressOffset>
+          <fields>
+            <field>
+              <name>TS3</name>
+              <description>TS3</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ERTPE</name>
+          <addressOffset>0x114</addressOffset>
+          <fields>
+            <field>
+              <name>ERTPE</name>
+              <description>ERTPE</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGTPE</name>
+          <description>Flash PRGTPE register</description>
+          <addressOffset>0x11C</addressOffset>
+          <fields>
+            <field>
+              <name>PRGTPE</name>
+              <description>PRGTPE</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRETPE</name>
+          <description>Flash PRETPE register</description>
+          <addressOffset>0x120</addressOffset>
+          <fields>
+            <field>
+              <name>PRETPE</name>
+              <description>PRETPE</description>
+              <bitRange>[13:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General-purpose I/Os</description>
+      <baseAddress>0x50000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>MODE7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>OT2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OT3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OT4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OT5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>OT6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>OT7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>OSPEED7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>PUPD2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>PUPD3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>PUPD4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>PUPD5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>PUPD6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>PUPD7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitRange>[15:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID2</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID3</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID4</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID5</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID6</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID7</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>OD2</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OD3</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OD4</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>OD5</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>OD6</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>OD7</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL2</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL3</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL4</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL5</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL6</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>AFSEL7</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port Reset bit</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port Reset bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port Reset bit</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port Reset bit</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port Reset bit</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Port Reset bit</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x50000400</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOC</name>
+      <description>General-purpose I/Os</description>
+      <baseAddress>0x50000800</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>KR</name>
+          <description>Key register (IWDG_KR)</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <description>Prescaler register (IWDG_PR)</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLR</name>
+          <description>Reload register (IWDG_RLR)</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload value</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value update</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value update</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>LPTIM1</name>
+      <description>Low power timer</description>
+      <groupName>LPTIM</groupName>
+      <baseAddress>0x40007C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>LPTIM1_DAC</name>
+        <description>LPTIM1, DAC global Interrupts</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <description>Interrupt and Status Register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>ARRM</name>
+              <description>Autoreload match</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ARROK</name>
+              <description>Autoreload match update OK</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>ARRMCF</name>
+              <description>Autoreload match Clear Flag</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ARROKCF</name>
+              <description>Autoreload match update OK Clear Flag</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <description>Interrupt Enable Register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>ARRMIE</name>
+              <description>Autoreload matchInterrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ARROKIE</name>
+              <description>Autoreload match update OK Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <description>Configuration Register</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>PRESC</name>
+              <description>Clock prescaler</description>
+              <bitRange>[11:9]</bitRange>
+            </field>
+            <field>
+              <name>PRELOAD</name>
+              <description>Registers update mode</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <description>Control Register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>LPTIM Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SNGSTRT</name>
+              <description>LPTIM start in single mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CNTSTRT</name>
+              <description>CNTSTRT</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>COUNTRST</name>
+              <description>Reset counter</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>RSTARE</name>
+              <description>Reset after read enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>Autoreload Register</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>Auto reload value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>Counter Register</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>Counter value</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWM</name>
+      <baseAddress>0x40002800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>URS</name>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>DIR</name>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CMS</name>
+              <bitRange>[6:5]</bitRange>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>LEDEN</name>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>LEDCEN</name>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>LEDWORD</name>
+              <bitRange>[19:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1IE</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LED1_ENDIE</name>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1IF</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LED1_ENDIF</name>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>UG</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CMR</name>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>OC1M</name>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CER</name>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>C1E</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>C1P</name>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <addressOffset>0x34</addressOffset>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LED1_DATA</name>
+          <addressOffset>0x50</addressOffset>
+          <fields>
+            <field>
+              <name>LED1_DATA</name>
+              <bitRange>[23:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>Power control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>FLS_SLPTIME</name>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>VR_MODE</name>
+              <bitRange>[15:14]</bitRange>
+            </field>
+            <field>
+              <name>HSION_CTRL</name>
+              <bitRange>[22:22]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>PVDE</name>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PVDT</name>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>PVD_OUT_SEL</name>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>FLTEN</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>FLT_TIME</name>
+              <bitRange>[11:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>PVDO</name>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RCC</name>
+        <description>RCC global Interrupt</description>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR</name>
+          <description>Clock control register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>HSION</name>
+              <description>HSI clock enable bit</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>HSI clock ready logo</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>HSIDIV</name>
+              <description>HSI generates the crossover factor when HSISYS clocks</description>
+              <bitRange>[13:11]</bitRange>
+            </field>
+            <field>
+              <name>HSEON</name>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICSCR</name>
+          <description>Internal clock sources calibration register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>HSI_ABS_TRIMCR</name>
+              <description>Clock frequency calibration value</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>HSI_TC_TRIMCR</name>
+              <description>HSI frequency selection</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>HSI_FS</name>
+              <description>HSI frequency selection</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>LSI_TRIM</name>
+              <bitRange>[27:19]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <description>Clock configuration register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>SW</name>
+              <description>System clock source selection</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+            <field>
+              <name>SWS</name>
+              <description>System clock source selection</description>
+              <bitRange>[5:3]</bitRange>
+            </field>
+            <field>
+              <name>HPRE</name>
+              <description>The AHB clock HCLK is based on the crossover coefficient of SYSCLK</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>PPRE</name>
+              <description>APB clock division factor</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>MCOSEL</name>
+              <description>MCO output clock selection</description>
+              <bitRange>[26:24]</bitRange>
+            </field>
+            <field>
+              <name>MCOPRE</name>
+              <description>Microprocessor output clock (MCO) divider factor</description>
+              <bitRange>[30:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECSCR</name>
+          <description>External clock source control register</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>LSE_DRIVER</name>
+              <description>LSE drive capability setting</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+            <field>
+              <name>LSE_STARTUP</name>
+              <description>LSE crystal oscillator stabilization time selection</description>
+              <bitRange>[21:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIER</name>
+          <description>Clock interrupt enable register</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>LSIRDYIE</name>
+              <description>LSI clock ready interrupt enabled</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDYIE</name>
+              <description>LSE clock ready interrupt enabled</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>HSIRDYIE</name>
+              <description>HSI clock ready interrupt enabled</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIFR</name>
+          <description>Clock interrupt flag register</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>LSIRDYF</name>
+              <description>LSI clock ready interrupt flag</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LSERDYF</name>
+              <description>LSE clock ready interrupt flag</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>HSIRDYF</name>
+              <description>HSI clock ready interrupt flag</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LSECSSF</name>
+              <description>LSE Clock Security System (CSS) interrupt flag</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CICR</name>
+          <description>Clock interrupt clear register</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>LSIRDYC</name>
+              <description>The LSI ready interrupt flag is cleared</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>LSERDYC</name>
+              <description>The LSE ready interrupt flag is cleared</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>HSIRDYC</name>
+              <description>The HSI ready interrupt flag is cleared to zero</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>LSECSSC</name>
+              <description>The LSE Clock Security System (CSS) interrupt flag is cleared</description>
+              <bitRange>[9:9]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPRSTR</name>
+          <description>GPIO reset register</description>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>GPIOARST</name>
+              <description>I/O PortA reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>GPIOBRST</name>
+              <description>I/O PortB reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>GPIOCRST</name>
+              <description>I/O PortC reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR1</name>
+          <description>APB peripheral reset register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>UARTRST</name>
+              <description>The UART module is reset</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>DBGRST</name>
+              <description>The MCU Debug module is reset</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>PWRRST</name>
+              <description>The Power interface module is reset.</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>LPTIMRST</name>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR2</name>
+          <description>APB peripheral reset register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCFGRST</name>
+              <description>The SYSCFG module is reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWMRST</name>
+              <description>The PWM module is reset</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIM1RST</name>
+              <description>The TIM1 module is reset</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIM14RST</name>
+              <description>The TIM14 module is reset</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>ADCRST</name>
+              <description>The ADC block is reset</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>VREFBUFRST</name>
+              <bitRange>[26:26]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPENR</name>
+          <description>GPIO clock enable register</description>
+          <addressOffset>0x34</addressOffset>
+          <fields>
+            <field>
+              <name>GPIOAEN</name>
+              <description>I/O PortA clock enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>GPIOBEN</name>
+              <description>I/O PortB clock enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>GPIOCEN</name>
+              <description>I/O PortC clock enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBENR</name>
+          <description>AHB peripheral clock enable register</description>
+          <addressOffset>0x38</addressOffset>
+          <fields>
+            <field>
+              <name>FLASHEN</name>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SRAMEN</name>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR1</name>
+          <description>APB peripheral clock enable register 1</description>
+          <addressOffset>0x3C</addressOffset>
+          <fields>
+            <field>
+              <name>UARTEN</name>
+              <description>The UART module clock is enabled</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>DBGEN</name>
+              <description>MCU Debug module clock enable</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>PWREN</name>
+              <description>The Power interface module clock enables</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>LPTIMEN</name>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR2</name>
+          <description>APB peripheral clock enable register 2</description>
+          <addressOffset>0x40</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCFGEN</name>
+              <description>The SYSCFG module clock is enabled</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWMEN</name>
+              <description>The PWM module clock is enabled</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>The TIM1 module clock is enabled</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIM14EN</name>
+              <description>TIM14 module clock enable</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>ADCEN</name>
+              <description>ADC block clock enabled</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>VREFBUFEN</name>
+              <bitRange>[26:26]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCIPR</name>
+          <description>Peripherals independent clock configuration register</description>
+          <addressOffset>0x54</addressOffset>
+          <fields>
+            <field>
+              <name>PVDSEL</name>
+              <description>PVD module clock source selection</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>LPTIM1SEL</name>
+              <bitRange>[19:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDCR</name>
+          <description>RTC domain control register</description>
+          <addressOffset>0x5C</addressOffset>
+          <fields>
+            <field>
+              <name>LSEON</name>
+              <description>LSE OSC enabled</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSERDY</name>
+              <description>LSE OSC ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LSEBYP</name>
+              <description>LSE OSC bypass</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSON</name>
+              <description>LSE CSS enables</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>LSECSSD</name>
+              <description>LSE CSS (clock security system) detection failed</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>LSCSEL</name>
+              <description>Low-speed clock selection</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <description>Control/status register</description>
+          <addressOffset>0x60</addressOffset>
+          <fields>
+            <field>
+              <name>LSION</name>
+              <description>LSI OSC enabled</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>LSIRDY</name>
+              <description>LSI OSC stability flag</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PINRST_FLTDIS</name>
+              <description>NRST filtering is prohibited</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>RMVF</name>
+              <description>Clear the reset flag</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>OBLRSTF</name>
+              <description>Option byte loader reset flag</description>
+              <bitRange>[25:25]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>External NRST pin reset flag</description>
+              <bitRange>[26:26]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PORRSTF</name>
+              <description>POR reset flag</description>
+              <bitRange>[27:27]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Soft reset flag</description>
+              <bitRange>[28:28]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>IWDG reset flag</description>
+              <bitRange>[29:29]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCFG</name>
+      <description>System configuration controller</description>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR2</name>
+          <description>SYSCFG configuration register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>LOCKUP_LOCK</name>
+              <description>Cortex-M0+ LOCKUP bit enable bit</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PVD_LOCK</name>
+              <description>PVD LOCK selection</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIO_ENS</name>
+          <description>desc GPIO_ENS</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>PA_ENS</name>
+              <description>desc PA_ENS</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>PB_ENS</name>
+              <description>desc PB_ENS</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+            <field>
+              <name>PC_ENS</name>
+              <description>desc PC_ENS</description>
+              <bitRange>[17:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK_UP_TRG_COM</name>
+        <description>TIM1 Break, Update, Trigger and Commutation Interrupt</description>
+        <value>13</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Compare Interrupt</description>
+        <value>14</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>desc DIR</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CMS</name>
+              <description>desc CMS</description>
+              <bitRange>[6:5]</bitRange>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>CCPC</name>
+              <description>desc CCPC</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CCUS</name>
+              <description>desc CCUS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>MMS</name>
+              <description>desc MMS</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>TI1S</name>
+              <description>desc TI1S</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>OIS1</name>
+              <description>desc OIS1</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>OIS1N</name>
+              <description>desc OIS1N</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>OIS2</name>
+              <description>desc OIS2</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OIS2N</name>
+              <description>desc OIS2N</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OIS3</name>
+              <description>desc OIS3</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>OIS3N</name>
+              <description>desc OIS3N</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>desc OIS4</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCR</name>
+          <description>desc SMCR</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>SMS</name>
+              <description>desc SMS</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+            <field>
+              <name>OCCS</name>
+              <description>desc OCCS</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TS</name>
+              <description>desc TS</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>MSM</name>
+              <description>desc MSM</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>ETF</name>
+              <description>desc ETF</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ETPS</name>
+              <description>desc ETPS</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+            <field>
+              <name>ECE</name>
+              <description>desc ECE</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>desc ETP</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC2IE</name>
+              <description>desc CC2IE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC3IE</name>
+              <description>desc CC3IE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC4IE</name>
+              <description>desc CC4IE</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMIE</name>
+              <description>desc COMIE</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>desc TIE</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BIE</name>
+              <description>desc BIE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC2IF</name>
+              <description>desc CC2IF</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC3IF</name>
+              <description>desc CC3IF</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC4IF</name>
+              <description>desc CC4IF</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMIF</name>
+              <description>desc COMIF</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIF</name>
+              <description>desc TIF</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BIF</name>
+              <description>desc BIF</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>desc CC2OF</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CC3OF</name>
+              <description>desc CC3OF</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>desc CC4OF</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>IC2IR</name>
+              <description>desc IC2IR</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>IC3IR</name>
+              <description>desc IC3IR</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>IC4IR</name>
+              <description>desc IC3IR</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>IC2IF</name>
+              <description>desc IC2IF</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>IC3IF</name>
+              <description>desc IC3IF</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>IC4IF</name>
+              <description>desc IC3IF</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC2G</name>
+              <description>desc CC2G</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC3G</name>
+              <description>desc CC3G</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC4G</name>
+              <description>desc CC4G</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMG</name>
+              <description>desc COMG</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TG</name>
+              <description>desc TG</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>desc BG</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1FE</name>
+              <description>desc OC1FE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>OC1CE</name>
+              <description>desc OC1CE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OC2FE</name>
+              <description>desc OC2FE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OC2PE</name>
+              <description>desc OC2PE</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OC2M</name>
+              <description>desc OC2M</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>desc OC2CE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>IC2PSC</name>
+              <description>desc IC2PSC</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>desc IC2F</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_OUTPUT</name>
+          <description>desc CCMR2:OUTPUT</description>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC3FE</name>
+              <description>desc OC3FE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OC3PE</name>
+              <description>desc OC3PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC3M</name>
+              <description>desc OC3M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+            <field>
+              <name>OC3CE</name>
+              <description>desc OC3CE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OC4FE</name>
+              <description>desc OC4FE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OC4PE</name>
+              <description>desc OC4PE</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>OC4M</name>
+              <description>desc OC4M</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>desc OC4CE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_INPUT</name>
+          <description>desc CCMR2:INPUT</description>
+          <alternateRegister>CCMR2_OUTPUT</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC3PSC</name>
+              <description>desc IC3PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC3F</name>
+              <description>desc IC3F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>IC4PSC</name>
+              <description>desc IC4PSC</description>
+              <bitRange>[11:10]</bitRange>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>desc IC4F</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1NE</name>
+              <description>desc CC1NE</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CC2E</name>
+              <description>desc CC2E</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>desc CC2P</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CC2NE</name>
+              <description>desc CC2NE</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CC2NP</name>
+              <description>desc CC2NP</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CC3E</name>
+              <description>desc CC3E</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CC3P</name>
+              <description>desc CC3P</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CC3NE</name>
+              <description>desc CC3NE</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CC3NP</name>
+              <description>desc CC3NP</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CC4E</name>
+              <description>desc CC4E</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>desc CC4P</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCR</name>
+          <description>desc RCR</description>
+          <addressOffset>0x30</addressOffset>
+          <fields>
+            <field>
+              <name>REP</name>
+              <description>desc REP</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+            <field>
+              <name>CCR1_H</name>
+              <description>desc CCR1_H</description>
+              <bitRange>[31:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR2</name>
+          <description>desc CCR2</description>
+          <addressOffset>0x38</addressOffset>
+          <fields>
+            <field>
+              <name>CCR2</name>
+              <description>desc CCR2</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+            <field>
+              <name>CCR2_H</name>
+              <description>desc CCR2_H</description>
+              <bitRange>[31:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR3</name>
+          <description>desc CCR3</description>
+          <addressOffset>0x3C</addressOffset>
+          <fields>
+            <field>
+              <name>CCR3</name>
+              <description>desc CCR3</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+            <field>
+              <name>CCR3_H</name>
+              <description>desc CCR3_H</description>
+              <bitRange>[31:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR4</name>
+          <description>desc CCR4</description>
+          <addressOffset>0x40</addressOffset>
+          <fields>
+            <field>
+              <name>CCR4</name>
+              <description>desc CCR4</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <description>desc BDTR</description>
+          <addressOffset>0x44</addressOffset>
+          <fields>
+            <field>
+              <name>DTG</name>
+              <description>desc DTG</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>desc LOCK</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>OSSI</name>
+              <description>desc OSSI</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>OSSR</name>
+              <description>desc OSSR</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>BKE</name>
+              <description>desc BKE</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>BKP</name>
+              <description>desc BKP</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>AOE</name>
+              <description>desc AOE</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>desc MOE</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TISEL</name>
+          <addressOffset>0x5C</addressOffset>
+          <fields>
+            <field>
+              <name>TI1SEL</name>
+              <description>desc TI1SEL</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>TI2SEL</name>
+              <description>desc TI2SEL</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>TI3SEL</name>
+              <description>desc TI3SEL</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>TI4SEL</name>
+              <description>desc TI4SEL</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AF1</name>
+          <addressOffset>0x60</addressOffset>
+          <fields>
+            <field>
+              <name>BKINE</name>
+              <description>desc BKINE</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>BKCMP1E</name>
+              <description>desc BKCMP1E</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>BKCMP2E</name>
+              <description>desc BKCMP2E</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BKINP</name>
+              <description>desc BKINP</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>BKCMP1P</name>
+              <description>desc BKCMP1P</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>BKCMP2P</name>
+              <description>desc BKCMP2P</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>ETRSEL</name>
+              <description>desc ETRSEL</description>
+              <bitRange>[17:14]</bitRange>
+            </field>
+            <field>
+              <name>INTR_SEL</name>
+              <description>desc INTR_SEL</description>
+              <bitRange>[19:18]</bitRange>
+            </field>
+            <field>
+              <name>PWM_PHS_EN</name>
+              <description>desc PWM_PHS_EN</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AF2</name>
+          <addressOffset>0x64</addressOffset>
+          <fields>
+            <field>
+              <name>OCRSEL</name>
+              <description>desc OCRSEL</description>
+              <bitRange>[18:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM14</name>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40002400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <addressOffset>0xC</addressOffset>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <bitRange>[6:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <bitRange>[3:2]</bitRange>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <addressOffset>0x2C</addressOffset>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <addressOffset>0x34</addressOffset>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TISEL</name>
+          <addressOffset>0x5C</addressOffset>
+          <fields>
+            <field>
+              <name>TI1SEL</name>
+              <description>desc TI1SEL</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>UART1</name>
+      <groupName>UART</groupName>
+      <baseAddress>0x40004800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DR</name>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Receive/send data register</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>BRR</name>
+              <description>Baud rate register</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <addressOffset>0x10</addressOffset>
+          <fields>
+            <field>
+              <name>RXNE</name>
+              <description>Receive register not empty</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ORE</name>
+              <description>Overrun error bit</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Parity Error bit</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FE</name>
+              <description>Framing Error bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>BRI</name>
+              <description>Break Interrupt bit</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TDRE</name>
+              <description>Transmit Holding Register Empty bit</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>Transmitter Empty bit</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDR_RCVD</name>
+              <description>Address Received Bit</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>UART Busy</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY_ERR</name>
+              <description>Busy Detect Error</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR1</name>
+          <addressOffset>0x14</addressOffset>
+          <fields>
+            <field>
+              <name>M</name>
+              <description>Data Length Select</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>STOP</name>
+              <description>Number of stop bits</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PCE</name>
+              <description>Parity Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PS</name>
+              <description>Even Parity Select</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SP</name>
+              <description>Stick Parity</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SBK</name>
+              <description>Send Break</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>TX/RX pin swap</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>MSBFIRST</name>
+              <description>MSB first mode</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <addressOffset>0x18</addressOffset>
+          <fields>
+            <field>
+              <name>RXNEIE</name>
+              <description>Enable Received Data Available Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TDREIE</name>
+              <description>Enable Transmit Holding Register Empty Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>LSIE</name>
+              <description>Enable Receiver Line Status Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>BUSYERRIE</name>
+              <description>Enable Busyerr state interruption</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>Enable tx empty interruption</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR3</name>
+          <addressOffset>0x1C</addressOffset>
+          <fields>
+            <field>
+              <name>M_E</name>
+              <description>Extension for DLS</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADDR_MATCH</name>
+              <description>Address Match Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SEND_ADDR</name>
+              <description>Send address control bit</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TX_MODE</name>
+              <description>Transmit mode control bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>DMAR</name>
+              <description>DMA receive enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>DMAT</name>
+              <description>DMA transmit enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>DMA_SOFT_ACK</name>
+              <description>DMA software ack</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RAR</name>
+          <addressOffset>0x20</addressOffset>
+          <fields>
+            <field>
+              <name>RAR</name>
+              <description>Receive address matching register</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAR</name>
+          <addressOffset>0x24</addressOffset>
+          <fields>
+            <field>
+              <name>TAR</name>
+              <description>Transmit address matching register</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRRF</name>
+          <addressOffset>0x28</addressOffset>
+          <fields>
+            <field>
+              <name>BRRF</name>
+              <description>Baud rate fractional register</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>VREF</name>
+      <baseAddress>0x40010100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR</name>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>VREFBUF_OUT_SEL</name>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>VREFBUF_EN</name>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/MS32C001xx.svd
+++ b/svd/MS32C001xx.svd
@@ -1,0 +1,5088 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>MS</vendor>
+  <vendorID>MS</vendorID>
+  <name>MS32Cxxx_DFP</name>  <!-- name of part-->
+  <series>MS32C</series>
+  <version>1.0.0</version>
+  <description>Arm 32-bit Cortex-M0+ Microcontroller based device, CPU clock up to 24 MHz.</description>
+  <cpu>    <!-- details about the cpu embedded in the device -->
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <addressUnitBits>8</addressUnitBits>  <!-- byte addressable memory -->
+  <width>32</width>  <!-- bus width is 32 bits -->  <!-- default settings implicitly inherited by subsequent sections -->
+  <size>32</size>  <!-- this is the default size (number of bits) of all peripherals and register that do not define "size" themselves -->
+  <access>read-write</access>  <!-- default access permission for all subsequent registers -->
+  <resetValue>0x00000000</resetValue>  <!-- by default all bits of the registers are initialized to 0 on reset -->
+  <resetMask>0xFFFFFFFF</resetMask>  <!-- by default all 32Bits of the registers are used -->
+  <peripherals>
+    <peripheral>
+      <name>ADC</name>
+      <description>Analog to Digital Converter</description>
+      <groupName>ADC</groupName>
+      <baseAddress>0x40012400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <description>ADC Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>ADC interrupt and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWD</name>
+              <description>ADC analog watchdog flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>ADC group regular overrun flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSEQ</name>
+              <description>ADC group regular end of sequence conversions flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOC</name>
+              <description>ADC group regular end of unitary conversion flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSMP</name>
+              <description>ADC group regular end of sampling flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>ADC interrupt enable register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWDIE</name>
+              <description>ADC analog watchdog interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVRIE</name>
+              <description>ADC group regular overrun interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSEQIE</name>
+              <description>ADC group regular end of sequence conversions interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOCIE</name>
+              <description>ADC group regular end of unitary conversion interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSMPIE</name>
+              <description>ADC group regular end of sampling interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>ADC control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ADCAL</name>
+              <description>ADC group regular conversion calibration</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VERBUFF_SEL</name>
+              <description>desc VERBUFF_SEL</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>VREF_BUFFERE</name>
+              <description>desc VREF_BUFFERE</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADSTP</name>
+              <description>ADC group regular conversion stop</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADSTART</name>
+              <description>ADC group regular conversion start</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDIS</name>
+              <description>ADC enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADEN</name>
+              <description>ADC enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>ADC configuration register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWDCH</name>
+              <description>ADC analog watchdog monitored channel selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AWDEN</name>
+              <description>ADC analog watchdog enable on scope ADC group regular</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDSGL</name>
+              <description>ADC analog watchdog monitoring a single channel or all channels</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DISCEN</name>
+              <description>ADC group regular sequencer discontinuous mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAIT</name>
+              <description>Wait conversion mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CONT</name>
+              <description>ADC group regular continuous conversion mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVRMOD</name>
+              <description>ADC group regular overrun configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTEN</name>
+              <description>ADC group regular external trigger polarity</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTSEL</name>
+              <description>ADC group regular external trigger source</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>ALIGN</name>
+              <description>ADC data alignement</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>ADC data resolution</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCANDIR</name>
+              <description>Scan sequence direction</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>ADC configuration register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CKMODE</name>
+              <description>ADC clock mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMPR</name>
+          <displayName>SMPR</displayName>
+          <description>ADC sampling time register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SMP</name>
+              <description>Sampling time selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TR</name>
+          <displayName>TR</displayName>
+          <description>ADC analog watchdog 1 threshold register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0FFF0000</resetValue>
+          <fields>
+            <field>
+              <name>HT</name>
+              <description>ADC analog watchdog threshold high</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LT</name>
+              <description>ADC analog watchdog threshold low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSELR</name>
+          <displayName>CHSELR</displayName>
+          <description>ADC group regular sequencer register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0FFF0000</resetValue>
+          <fields>
+            <field>
+              <name>CHSEL9</name>
+              <description>Channel-9 selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL8</name>
+              <description>Channel-8 selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL7</name>
+              <description>Channel-7 selection</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL6</name>
+              <description>Channel-6 selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL5</name>
+              <description>Channel-5 selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL4</name>
+              <description>Channel-4 selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL3</name>
+              <description>Channel-3 selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL2</name>
+              <description>Channel-2 selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL1</name>
+              <description>Channel-1 selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL0</name>
+              <description>Channel-0 selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>ADC group regular data register</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>ADC group regular conversion data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCSR</name>
+          <displayName>CCSR</displayName>
+          <description>ADC calibration configuration and status register</description>
+          <addressOffset>0x44</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CALON</name>
+              <description>Calibration flag</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CALSUC</name>
+              <description>desc CALSUC</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OFFSUC</name>
+              <description>desc OFFSUC</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALSET</name>
+              <description>Calibration factor selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALBYP</name>
+              <description>desc CALBYP</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALSMP</name>
+              <description>Calibration sample time selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CALSEL</name>
+              <description>Calibration contents selection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <displayName>CCR</displayName>
+          <description>ADC common configuration register</description>
+          <addressOffset>0x308</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature sensor enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VREFEN</name>
+              <description>VREFINT enable</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <groupName>RCC</groupName>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RCC</name>
+        <description>RCC global Interrupt</description>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>HSEEN</name>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIDIV</name>
+              <description>HSI16 clock division factor</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>HSI16 clock ready flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSION</name>
+              <description>HSI16 clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICSCR</name>
+          <displayName>ICSCR</displayName>
+          <description>Internal clock sources calibration register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x10000000</resetValue>
+          <fields>
+            <field>
+              <name>LSI_STARTUP</name>
+              <description>LSI startup time</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSI_TRIM</name>
+              <description>LSI clock trimming</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_FS</name>
+              <description>HSI frequency selection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_TRIM</name>
+              <description>HSI clock trimming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Clock configuration register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MCOPRE</name>
+              <description>Microcontroller clock output prescaler</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MCOSEL</name>
+              <description>Microcontroller clock output</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PPRE</name>
+              <description>APB prescaler</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HPRE</name>
+              <description>AHB prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SWS</name>
+              <description>System clock switch status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SW</name>
+              <description>System clock switch</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECSCR</name>
+          <displayName>ECSCR</displayName>
+          <description>External clock source control register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSE_STARTUP</name>
+              <description>desc LSE_STARTUP</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSE_DRIVER</name>
+              <description>desc LSE_DRIVER</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIER</name>
+          <displayName>CIER</displayName>
+          <description>Clock interrupt enable register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>HSIRDYIE</name>
+              <description>HSI ready interrupt enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYIE</name>
+              <description>LSE ready interrupt enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYIE</name>
+              <description>LSI ready interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIFR</name>
+          <displayName>CIFR</displayName>
+          <description>Clock interrupt flag register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSF</name>
+              <description>LSE clock secure system interrupt flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYF</name>
+              <description>HSI ready interrupt flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYF</name>
+              <description>LSE ready interrupt flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYF</name>
+              <description>LSI ready interrupt flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CICR</name>
+          <displayName>CICR</displayName>
+          <description>Clock interrupt clear register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSC</name>
+              <description>LSE clock secure system interrupt flag clear</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYC</name>
+              <description>HSI ready interrupt clear</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYC</name>
+              <description>LSE ready interrupt clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYC</name>
+              <description>LSI ready interrupt clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPRSTR</name>
+          <displayName>IOPRSTR</displayName>
+          <description>GPIO reset register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCRST</name>
+              <description>I/O port C reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBRST</name>
+              <description>I/O port B reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOARST</name>
+              <description>I/O port A reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBRSTR</name>
+          <displayName>AHBRSTR</displayName>
+          <description>AHB peripheral reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCRST</name>
+              <description>CRC reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHRST</name>
+              <description>FLASH reset</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR1</name>
+          <displayName>APBRSTR1</displayName>
+          <description>APB peripheral reset register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMRST</name>
+              <description>Low Power Timer reset</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRST</name>
+              <description>Power interface reset</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGRST</name>
+              <description>Debug support reset</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR2</name>
+          <displayName>APBRSTR2</displayName>
+          <description>APB peripheral reset register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ADCRST</name>
+              <description>ADC reset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14RST</name>
+              <description>TIM14 reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1RST</name>
+              <description>TIM1 timer reset</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGRST</name>
+              <description>SYSCFG reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPENR</name>
+          <displayName>IOPENR</displayName>
+          <description>GPIO clock enable register</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCEN</name>
+              <description>I/O port C clock enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBEN</name>
+              <description>I/O port B clock enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOAEN</name>
+              <description>I/O port A clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBENR</name>
+          <displayName>AHBENR</displayName>
+          <description>AHB peripheral clock enable register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCEN</name>
+              <description>CRC clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAMEN</name>
+              <description>SRAM memory interface clock enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHEN</name>
+              <description>Flash memory interface clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR1</name>
+          <displayName>APBENR1</displayName>
+          <description>APB peripheral clock enable register 1</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMEN</name>
+              <description>LPTIM clock enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWREN</name>
+              <description>Power interface clock enable</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGEN</name>
+              <description>Debug support clock enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR2</name>
+          <displayName>APBENR2</displayName>
+          <description>APB peripheral clock enable register 2</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ADCEN</name>
+              <description>ADC clock enable</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14EN</name>
+              <description>TIM14 clock enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>TIM1 timer clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGEN</name>
+              <description>SYSCFG and VREFBUF clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCIPR</name>
+          <displayName>CCIPR</displayName>
+          <description>Peripherals independent clock configuration register</description>
+          <addressOffset>0x54</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIM1SEL</name>
+              <description>LPTIM1 clock source selection</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDCR</name>
+          <displayName>BDCR</displayName>
+          <description>RTC domain control register</description>
+          <addressOffset>0x5C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSCOSEL</name>
+              <description>Low-speed clock output selection</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSCOEN</name>
+              <description>Low-speed clock output (LSCO) enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSD</name>
+              <description>LSE CSS detect</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSON</name>
+              <description>LSE CSS enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEBYP</name>
+              <description>LSE oscillator bypass</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDY</name>
+              <description>LSE oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEON</name>
+              <description>LSE oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>Control/status register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>Independent window watchdog reset flag</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Software reset flag</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRSTF</name>
+              <description>BOR or POR/PDR flag</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>Pin reset flag</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBLRSTF</name>
+              <description>Option byte loader reset flag</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RMVF</name>
+              <description>Remove reset flags</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRST_FLTDIS</name>
+              <description>desc PINRST_FLTDIS</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDY</name>
+              <description>LSI oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSION</name>
+              <description>LSI oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <groupName>PWR</groupName>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Power control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00030000</resetValue>
+          <fields>
+            <field>
+              <name>HSION_CTRL</name>
+              <description>HSI open time control</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAM_RETV</name>
+              <description>SRAM retention voltage control</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>LPR</name>
+              <description>Low-power run</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FLS_SLPTIME</name>
+              <description>Flash wait time after wakeup from the stop mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+                        <field>
+              <name>BIAS_CR_SEL</name>
+              <description>MR Bias current selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CR</name>
+              <description>MR Bias current</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+              </registers>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID7</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID6</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID5</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID4</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID3</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID2</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD7</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD6</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD5</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD4</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD3</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD2</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL7</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL6</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL5</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL4</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL3</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL2</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port Reset bit</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port Reset bit</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port Reset bit</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port Reset bit</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port Reset bit</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port Reset bit</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x50000400</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>GPIOC</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>External interrupt/event controller</description>
+      <groupName>EXTI</groupName>
+      <baseAddress>0x40021800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EXTI0_1</name>
+        <description>EXTI Line 0 and 1 Interrupt</description>
+        <value>5</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI2_3</name>
+        <description>EXTI Line 2 and 3 Interrupt</description>
+        <value>6</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI4_15</name>
+        <description>EXTI Line 4 to 15 Interrupt</description>
+        <value>7</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>RTSR</name>
+          <displayName>RTSR</displayName>
+          <description>EXTI rising trigger selection register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RT18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTSR</name>
+          <displayName>FTSR</displayName>
+          <description>EXTI falling trigger selection register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FT18</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT17</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT7</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT6</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT5</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT4</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT3</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT2</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT1</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT0</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIER</name>
+          <displayName>SWIER</displayName>
+          <description>EXTI software interrupt event register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SWI18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>EXTI pending register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR18</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR17</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR7</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR6</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR5</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR4</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR3</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR2</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR1</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR0</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <displayName>EXTICR1</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI3</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI0</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <displayName>EXTICR2</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI7</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI4</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <displayName>IMR</displayName>
+          <description>EXTI CPU wakeup with interrupt mask register</description>
+          <addressOffset>0x80</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFF80000</resetValue>
+          <fields>
+            <field>
+              <name>IM29</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM18</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM17</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM7</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM6</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM5</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM4</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM3</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM2</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM1</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM0</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMR</name>
+          <displayName>EMR</displayName>
+          <description>EXTI CPU wakeup with event mask register</description>
+          <addressOffset>0x84</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EM29</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM18</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM17</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM7</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM6</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM5</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM4</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM3</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM2</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM1</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM0</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>LPTIM1</name>
+      <description>Low power timer</description>
+      <groupName>LPTIM1</groupName>
+      <baseAddress>0x40007C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>LPTIM1_DAC</name>
+        <description>LPTIM1, DAC global Interrupts</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>Interrupt and Status Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRM</name>
+              <description>Autoreload match</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROK</name>
+              <description>Autoreload match update OK</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <displayName>ICR</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMCF</name>
+              <description>Autoreload match Clear Flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKCF</name>
+              <description>Autoreload match update OK Clear Flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>Interrupt Enable Register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMIE</name>
+              <description>Autoreload matchInterrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKIE</name>
+              <description>Autoreload match update OK Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Configuration Register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PRELOAD</name>
+              <description>Registers update mode</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Clock prescaler</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control Register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RSTARE</name>
+              <description>Reset after read enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNTRST</name>
+              <description>Reset counter</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTSTRT</name>
+              <description>CNTSTRT</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SNGSTRT</name>
+              <description>LPTIM start in single mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>LPTIM Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <displayName>ARR</displayName>
+          <description>Autoreload Register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>Auto reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>Counter Register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>Counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <groupName>IWDG</groupName>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>KR</name>
+          <displayName>KR</displayName>
+          <description>Key register (IWDG_KR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>Prescaler register (IWDG_PR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLR</name>
+          <displayName>RLR</displayName>
+          <description>Reload register (IWDG_RLR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000FFF</resetValue>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value update</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK_UP_TRG_COM</name>
+        <description>TIM1 Break, Update, Trigger and Commutation Interrupt</description>
+        <value>13</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Compare Interrupt</description>
+        <value>14</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>desc DIR</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CMS</name>
+              <description>desc CMS</description>
+              <msb>6</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xF8</resetMask>
+          <fields>
+            <field>
+              <name>CCPC</name>
+              <description>desc CCPC</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CCUS</name>
+              <description>desc CCUS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MMS</name>
+              <description>desc MMS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TI1S</name>
+              <description>desc TI1S</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1</name>
+              <description>desc OIS1</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1N</name>
+              <description>desc OIS1N</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2</name>
+              <description>desc OIS2</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2N</name>
+              <description>desc OIS2N</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3</name>
+              <description>desc OIS3</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3N</name>
+              <description>desc OIS3N</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>desc OIS4</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCR</name>
+          <description>desc SMCR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFF7</resetMask>
+          <fields>
+            <field>
+              <name>SMS</name>
+              <description>desc SMS</description>
+              <msb>2</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OCCS</name>
+              <description>desc OCCS</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TS</name>
+              <description>desc TS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MSM</name>
+              <description>desc MSM</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETF</name>
+              <description>desc ETF</description>
+              <msb>11</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETPS</name>
+              <description>desc ETPS</description>
+              <msb>13</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ECE</name>
+              <description>desc ECE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>desc ETP</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IE</name>
+              <description>desc CC2IE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IE</name>
+              <description>desc CC3IE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IE</name>
+              <description>desc CC4IE</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIE</name>
+              <description>desc COMIE</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>desc TIE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIE</name>
+              <description>desc BIE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IF</name>
+              <description>desc CC2IF</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IF</name>
+              <description>desc CC3IF</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IF</name>
+              <description>desc CC4IF</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIF</name>
+              <description>desc COMIF</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIF</name>
+              <description>desc TIF</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIF</name>
+              <description>desc BIF</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>desc CC2OF</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3OF</name>
+              <description>desc CC3OF</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>desc CC4OF</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IR</name>
+              <description>desc IC2IR</description>
+              <msb>17</msb>
+              <lsb>17</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IR</name>
+              <description>desc IC3IR</description>
+              <msb>18</msb>
+              <lsb>18</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IR</name>
+              <description>desc IC3IR</description>
+              <msb>19</msb>
+              <lsb>19</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IF</name>
+              <description>desc IC2IF</description>
+              <msb>21</msb>
+              <lsb>21</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IF</name>
+              <description>desc IC3IF</description>
+              <msb>22</msb>
+              <lsb>22</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IF</name>
+              <description>desc IC3IF</description>
+              <msb>23</msb>
+              <lsb>23</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC2G</name>
+              <description>desc CC2G</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC3G</name>
+              <description>desc CC3G</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC4G</name>
+              <description>desc CC4G</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>COMG</name>
+              <description>desc COMG</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TG</name>
+              <description>desc TG</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>desc BG</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1FE</name>
+              <description>desc OC1FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1CE</name>
+              <description>desc OC1CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2FE</name>
+              <description>desc OC2FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2PE</name>
+              <description>desc OC2PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2M</name>
+              <description>desc OC2M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>desc OC2CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2PSC</name>
+              <description>desc IC2PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>desc IC2F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_OUTPUT</name>
+          <description>desc CCMR2:OUTPUT</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3FE</name>
+              <description>desc OC3FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3PE</name>
+              <description>desc OC3PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3M</name>
+              <description>desc OC3M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3CE</name>
+              <description>desc OC3CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4FE</name>
+              <description>desc OC4FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4PE</name>
+              <description>desc OC4PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4M</name>
+              <description>desc OC4M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>desc OC4CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_INPUT</name>
+          <description>desc CCMR2:INPUT</description>
+          <alternateRegister>CCMR2_OUTPUT</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3PSC</name>
+              <description>desc IC3PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3F</name>
+              <description>desc IC3F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4PSC</name>
+              <description>desc IC4PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>desc IC4F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NE</name>
+              <description>desc CC1NE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2E</name>
+              <description>desc CC2E</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>desc CC2P</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NE</name>
+              <description>desc CC2NE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NP</name>
+              <description>desc CC2NP</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3E</name>
+              <description>desc CC3E</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3P</name>
+              <description>desc CC3P</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NE</name>
+              <description>desc CC3NE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NP</name>
+              <description>desc CC3NP</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4E</name>
+              <description>desc CC4E</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>desc CC4P</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCR</name>
+          <description>desc RCR</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>REP</name>
+              <description>desc REP</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR2</name>
+          <description>desc CCR2</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR2</name>
+              <description>desc CCR2</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR3</name>
+          <description>desc CCR3</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR3</name>
+              <description>desc CCR3</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR4</name>
+          <description>desc CCR4</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR4</name>
+              <description>desc CCR4</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <description>desc BDTR</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>DTG</name>
+              <description>desc DTG</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>desc LOCK</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSI</name>
+              <description>desc OSSI</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSR</name>
+              <description>desc OSSR</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKE</name>
+              <description>desc BKE</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKP</name>
+              <description>desc BKP</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>AOE</name>
+              <description>desc AOE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>desc MOE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM14</name>
+      <description>General purpose timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40002000</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM14</name>
+        <description>TIM14 global Interrupt</description>
+        <value>19</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OR</name>
+          <description>desc OR</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>TI1_RMP</name>
+              <description>desc TI1_RMP</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCFG</name>
+      <description>System configuration controller</description>
+      <groupName>SYSCFG</groupName>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>SYSCFG configuration register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MEM_MODE</name>
+              <description>Memory mapping selection bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>SYSCFG configuration register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ETR_SRC_TIM1</name>
+              <description>TIM1 ETR source selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOCKUP_LOCK</name>
+              <description>Cortex-M0+ LOCKUP bit enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIO_ENS</name>
+          <description>desc GPIO_ENS</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>PC_ENS</name>
+              <description>desc PC_ENS</description>
+              <msb>17</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PB_ENS</name>
+              <description>desc PB_ENS</description>
+              <msb>15</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PA_ENS</name>
+              <description>desc PA_ENS</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>Flash</description>
+      <groupName>Flash</groupName>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>FLASH global Interrupt</description>
+        <value>3</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ACR</name>
+          <displayName>ACR</displayName>
+          <description>Access control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000600</resetValue>
+          <fields>
+            <field>
+              <name>LATENCY</name>
+              <description>Latency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>KEYR</name>
+          <displayName>KEYR</displayName>
+          <description>Flash key register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Flash key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTKEYR</name>
+          <displayName>OPTKEYR</displayName>
+          <description>Option byte key register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Option byte key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTVERR</name>
+              <description>Option and Engineering bits loading validity error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPERR</name>
+              <description>Write protected error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Flash control register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xC0000000</resetValue>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>FLASH_CR Lock</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTLOCK</name>
+              <description>Options Lock</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBL_LAUNCH</name>
+              <description>Force the option byte loading</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGSTRT</name>
+              <description>Flash main memory program start</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTSTRT</name>
+              <description>Option byte program start</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SER</name>
+              <description>Sector erase</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass erase</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Page erase</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PG</name>
+              <description>Programming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTR</name>
+          <displayName>OPTR</displayName>
+          <description>Flash option register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x4F55B0AA</resetValue>
+          <fields>
+            <field>
+              <name>NRST_MODE</name>
+              <description>NRST_MODE</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWD_MODE</name>
+              <description>SWD_MODE</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <description>Independent watchdog selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BORF_LEV</name>
+              <description>These bits contain the VDD supply level threshold that activates the reset</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>BOREN</name>
+              <description>BOR reset Level</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDKR</name>
+          <displayName>SDKR</displayName>
+          <description>Flash SDK address register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFE0001F</resetValue>
+          <fields>
+            <field>
+              <name>SDK_END</name>
+              <description>SDK area end address</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SDK_STRT</name>
+              <description>SDK area start address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BTCR</name>
+          <displayName>BTCR</displayName>
+          <description>FLASH boot control register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>NBOOT1</name>
+              <description>desc NBOOT1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT0</name>
+              <description>desc BOOT0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT_SIZE</name>
+              <description>desc BOOT_SIZE</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRPR</name>
+          <displayName>WRPR</displayName>
+          <description>Flash WRP address register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000FFFF</resetValue>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <description>WRP address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STCR</name>
+          <displayName>STCR</displayName>
+          <description>Flash sleep time config register</description>
+          <addressOffset>0x90</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00006400</resetValue>
+          <fields>
+            <field>
+              <name>SLEEP_TIME</name>
+              <description>FLash sleep time configuration(counter based on HSI_10M)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>SLEEP_EN</name>
+              <description>FLash sleep enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS0</name>
+          <displayName>TS0</displayName>
+          <description>Flash TS0 register</description>
+          <addressOffset>0x100</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS0</name>
+              <description>FLash TS0 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS1</name>
+          <displayName>TS1</displayName>
+          <description>Flash TS1 register</description>
+          <addressOffset>0x104</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000001B0</resetValue>
+          <fields>
+            <field>
+              <name>TS1</name>
+              <description>FLash TS1 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS2P</name>
+          <displayName>TS2P</displayName>
+          <description>Flash TS2P register</description>
+          <addressOffset>0x108</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS2P</name>
+              <description>FLash TS2P register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TPS3</name>
+          <displayName>TPS3</displayName>
+          <description>Flash TPS3 register</description>
+          <addressOffset>0x10C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000006C0</resetValue>
+          <fields>
+            <field>
+              <name>TPS3</name>
+              <description>FLash TPS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS3</name>
+          <displayName>TS3</displayName>
+          <description>Flash TS3 register</description>
+          <addressOffset>0x110</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS3</name>
+              <description>FLash TS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERTPE</name>
+          <displayName>PERTPE</displayName>
+          <description>Flash PERTPE register</description>
+          <addressOffset>0x114</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>PERTPE</name>
+              <description>FLash PERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMERTPE</name>
+          <displayName>SMERTPE</displayName>
+          <description>Flash SMERTPE register</description>
+          <addressOffset>0x118</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>SMERTPE</name>
+              <description>FLash SMERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGTPE</name>
+          <displayName>PRGTPE</displayName>
+          <description>Flash PRGTPE register</description>
+          <addressOffset>0x11C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00005DC0</resetValue>
+          <fields>
+            <field>
+              <name>PRGTPE</name>
+              <description>FLash PRGTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRETPE</name>
+          <displayName>PRETPE</displayName>
+          <description>Flash PRETPE register</description>
+          <addressOffset>0x120</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000012C0</resetValue>
+          <fields>
+            <field>
+              <name>PRETPE</name>
+              <description>FLash PRETPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>14</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <description>CRC calculation unit</description>
+      <groupName>CRC</groupName>
+      <baseAddress>0x40023000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>Independent Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IDR</name>
+              <description>Independent Data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RESET</name>
+              <description>Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBGMCU</name>
+      <description>Debug support</description>
+      <groupName>DBGMCU</groupName>
+      <baseAddress>0x40015800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>IDCODE</name>
+          <displayName>IDCODE</displayName>
+          <description>MCU Device ID Code Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>REV_ID</name>
+              <description>REV_ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Debug MCU Configuration Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_STOP</name>
+              <description>Debug Stop Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ1</name>
+          <displayName>APB_FZ1</displayName>
+          <description>APB Freeze Register1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_LPTIM_STOP</name>
+              <description>Debug LPTIM stopped when Core ishalted</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ2</name>
+          <displayName>APB_FZ2</displayName>
+          <description>APB Freeze Register2</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_TIM14_STOP</name>
+              <description>Debug TIM 14 stopped whenCore is halted</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBG_TIMER1_STOP</name>
+              <description>Debug Timer 1 stopped when Core ishalted</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/MS32C011xx.svd
+++ b/svd/MS32C011xx.svd
@@ -1,0 +1,5796 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>MS</vendor>
+  <vendorID>MS</vendorID>
+  <name>MS32Cxxx_DFP</name>  <!-- name of part-->
+  <series>MS32C</series>
+  <version>1.0.0</version>
+  <description>Arm 32-bit Cortex-M0+ Microcontroller based device, CPU clock up to 24 MHz.</description>
+  <cpu>    <!-- details about the cpu embedded in the device -->
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <addressUnitBits>8</addressUnitBits>  <!-- byte addressable memory -->
+  <width>32</width>  <!-- bus width is 32 bits -->  <!-- default settings implicitly inherited by subsequent sections -->
+  <size>32</size>  <!-- this is the default size (number of bits) of all peripherals and register that do not define "size" themselves -->
+  <access>read-write</access>  <!-- default access permission for all subsequent registers -->
+  <resetValue>0x00000000</resetValue>  <!-- by default all bits of the registers are initialized to 0 on reset -->
+  <resetMask>0xFFFFFFFF</resetMask>  <!-- by default all 32Bits of the registers are used -->
+  <peripherals>
+    <peripheral>
+      <name>COMP1</name>
+      <description>Comparator 1</description>
+      <groupName>COMP</groupName>
+      <baseAddress>0x40010200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>COMP</name>
+        <description>COMP Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>COMP control and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP_OUT</name>
+              <description>Comparator output status</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCSEL</name>
+              <description>VCSEL</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCDIV_EN</name>
+              <description>VCDIV_EN</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCDIV</name>
+              <description>VCDIV</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>POLARITY</name>
+              <description>Comparator polarity selector</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMODE</name>
+              <description>Comparator non-inverting input selector for window mode</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INNSEL</name>
+              <description>desc INNSEL</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>COMP enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FR</name>
+          <displayName>FR</displayName>
+          <description>Comparator Filter register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FLTCNT1</name>
+              <description>Comparator filter and counter</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FLTEN1</name>
+              <description>Filter enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>COMP2</name>
+      <description>Comparator2</description>
+      <groupName>COMP</groupName>
+      <baseAddress>0x40010210</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>COMP</name>
+        <description>COMP Interrupt</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>COMP control and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP_OUT</name>
+              <description>Comparator output status</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLARITY</name>
+              <description>Comparator polarity selector</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INPSEL</name>
+              <description>Comparator signal selector for non-inverting input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INMSEL</name>
+              <description>Comparator signal selector for inverting input INM</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>COMP enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FR</name>
+          <displayName>FR</displayName>
+          <description>Comparator Filter register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FLTCNT2</name>
+              <description>Comparator filter and counter</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FLTEN2</name>
+              <description>Filter enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <groupName>RCC</groupName>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RCC</name>
+        <description>RCC global Interrupt</description>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>HSEEN</name>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIDIV</name>
+              <description>HSI16 clock division factor</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>HSI16 clock ready flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSION</name>
+              <description>HSI16 clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICSCR</name>
+          <displayName>ICSCR</displayName>
+          <description>Internal clock sources calibration register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x10000000</resetValue>
+          <fields>
+            <field>
+              <name>LSI_STARTUP</name>
+              <description>LSI startup time</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSI_TRIM</name>
+              <description>LSI clock trimming</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_FS</name>
+              <description>HSI frequency selection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_TRIM</name>
+              <description>HSI clock trimming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Clock configuration register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MCOPRE</name>
+              <description>Microcontroller clock output prescaler</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MCOSEL</name>
+              <description>Microcontroller clock output</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PPRE</name>
+              <description>APB prescaler</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HPRE</name>
+              <description>AHB prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SWS</name>
+              <description>System clock switch status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SW</name>
+              <description>System clock switch</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECSCR</name>
+          <displayName>ECSCR</displayName>
+          <description>External clock source control register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSE_STARTUP</name>
+              <description>desc LSE_STARTUP</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSE_DRIVER</name>
+              <description>desc LSE_DRIVER</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIER</name>
+          <displayName>CIER</displayName>
+          <description>Clock interrupt enable register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>HSIRDYIE</name>
+              <description>HSI ready interrupt enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYIE</name>
+              <description>LSE ready interrupt enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYIE</name>
+              <description>LSI ready interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIFR</name>
+          <displayName>CIFR</displayName>
+          <description>Clock interrupt flag register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSF</name>
+              <description>LSE clock secure system interrupt flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYF</name>
+              <description>HSI ready interrupt flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYF</name>
+              <description>LSE ready interrupt flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYF</name>
+              <description>LSI ready interrupt flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CICR</name>
+          <displayName>CICR</displayName>
+          <description>Clock interrupt clear register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSC</name>
+              <description>LSE clock secure system interrupt flag clear</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYC</name>
+              <description>HSI ready interrupt clear</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYC</name>
+              <description>LSE ready interrupt clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYC</name>
+              <description>LSI ready interrupt clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPRSTR</name>
+          <displayName>IOPRSTR</displayName>
+          <description>GPIO reset register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCRST</name>
+              <description>I/O port C reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBRST</name>
+              <description>I/O port B reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOARST</name>
+              <description>I/O port A reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBRSTR</name>
+          <displayName>AHBRSTR</displayName>
+          <description>AHB peripheral reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCRST</name>
+              <description>CRC reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHRST</name>
+              <description>FLASH reset</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR1</name>
+          <displayName>APBRSTR1</displayName>
+          <description>APB peripheral reset register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMRST</name>
+              <description>Low Power Timer reset</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRST</name>
+              <description>Power interface reset</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGRST</name>
+              <description>Debug support reset</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2CRST</name>
+              <description>I2C reset</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR2</name>
+          <displayName>APBRSTR2</displayName>
+          <description>APB peripheral reset register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP2RST</name>
+              <description>COMP2 reset</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1RST</name>
+              <description>COMP1 reset</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADCRST</name>
+              <description>ADC reset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14RST</name>
+              <description>TIM14 reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USART1RST</name>
+              <description>USART1 reset</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPI1RST</name>
+              <description>SPI1 reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1RST</name>
+              <description>TIM1 timer reset</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGRST</name>
+              <description>SYSCFG and COMP reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPENR</name>
+          <displayName>IOPENR</displayName>
+          <description>GPIO clock enable register</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCEN</name>
+              <description>I/O port C clock enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBEN</name>
+              <description>I/O port B clock enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOAEN</name>
+              <description>I/O port A clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBENR</name>
+          <displayName>AHBENR</displayName>
+          <description>AHB peripheral clock enable register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCEN</name>
+              <description>CRC clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAMEN</name>
+              <description>SRAM memory interface clock enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHEN</name>
+              <description>Flash memory interface clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR1</name>
+          <displayName>APBENR1</displayName>
+          <description>APB peripheral clock enable register 1</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMEN</name>
+              <description>LPTIM clock enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWREN</name>
+              <description>Power interface clock enable</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGEN</name>
+              <description>Debug support clock enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2CEN</name>
+              <description>I2C clock enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR2</name>
+          <displayName>APBENR2</displayName>
+          <description>APB peripheral clock enable register 2</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP2EN</name>
+              <description>COMP2 clock enable</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1EN</name>
+              <description>COMP1 clock enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14EN</name>
+              <description>TIM14 clock enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USART1EN</name>
+              <description>USART1 clock enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPI1EN</name>
+              <description>SPI1 clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>TIM1 timer clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGEN</name>
+              <description>SYSCFG, COMP and VREFBUF clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCIPR</name>
+          <displayName>CCIPR</displayName>
+          <description>Peripherals independent clock configuration register</description>
+          <addressOffset>0x54</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIM1SEL</name>
+              <description>LPTIM1 clock source selection</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>COMP2SEL</name>
+              <description>COMP2 clock source selection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1SEL</name>
+              <description>COMP1 clock source selection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDCR</name>
+          <displayName>BDCR</displayName>
+          <description>RTC domain control register</description>
+          <addressOffset>0x5C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSCOSEL</name>
+              <description>Low-speed clock output selection</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSCOEN</name>
+              <description>Low-speed clock output (LSCO) enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSD</name>
+              <description>LSE CSS detect</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSON</name>
+              <description>LSE CSS enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEBYP</name>
+              <description>LSE oscillator bypass</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDY</name>
+              <description>LSE oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEON</name>
+              <description>LSE oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>Control/status register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>Independent window watchdog reset flag</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Software reset flag</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRSTF</name>
+              <description>BOR or POR/PDR flag</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>Pin reset flag</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBLRSTF</name>
+              <description>Option byte loader reset flag</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RMVF</name>
+              <description>Remove reset flags</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRST_FLTDIS</name>
+              <description>desc PINRST_FLTDIS</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDY</name>
+              <description>LSI oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSION</name>
+              <description>LSI oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <groupName>PWR</groupName>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Power control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00030000</resetValue>
+          <fields>
+            <field>
+              <name>HSION_CTRL</name>
+              <description>HSI open time control</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAM_RETV</name>
+              <description>SRAM retention voltage control</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>LPR</name>
+              <description>Low-power run</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FLS_SLPTIME</name>
+              <description>Flash wait time after wakeup from the stop mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+                        <field>
+              <name>BIAS_CR_SEL</name>
+              <description>MR Bias current selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CR</name>
+              <description>MR Bias current</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+              </registers>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID7</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID6</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID5</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID4</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID3</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID2</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD7</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD6</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD5</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD4</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD3</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD2</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL7</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL6</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL5</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL4</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL3</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL2</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port Reset bit</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port Reset bit</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port Reset bit</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port Reset bit</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port Reset bit</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port Reset bit</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x50000400</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>GPIOC</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>External interrupt/event controller</description>
+      <groupName>EXTI</groupName>
+      <baseAddress>0x40021800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EXTI0_1</name>
+        <description>EXTI Line 0 and 1 Interrupt</description>
+        <value>5</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI2_3</name>
+        <description>EXTI Line 2 and 3 Interrupt</description>
+        <value>6</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI4_15</name>
+        <description>EXTI Line 4 to 15 Interrupt</description>
+        <value>7</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>RTSR</name>
+          <displayName>RTSR</displayName>
+          <description>EXTI rising trigger selection register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RT18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTSR</name>
+          <displayName>FTSR</displayName>
+          <description>EXTI falling trigger selection register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FT18</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT17</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT7</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT6</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT5</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT4</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT3</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT2</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT1</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT0</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIER</name>
+          <displayName>SWIER</displayName>
+          <description>EXTI software interrupt event register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SWI18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>EXTI pending register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR18</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR17</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR7</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR6</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR5</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR4</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR3</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR2</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR1</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR0</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <displayName>EXTICR1</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI3</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI0</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <displayName>EXTICR2</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI7</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI4</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <displayName>IMR</displayName>
+          <description>EXTI CPU wakeup with interrupt mask register</description>
+          <addressOffset>0x80</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFF80000</resetValue>
+          <fields>
+            <field>
+              <name>IM29</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM18</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM17</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM7</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM6</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM5</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM4</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM3</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM2</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM1</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM0</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMR</name>
+          <displayName>EMR</displayName>
+          <description>EXTI CPU wakeup with event mask register</description>
+          <addressOffset>0x84</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EM29</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM18</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM17</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM7</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM6</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM5</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM4</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM3</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM2</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM1</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM0</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>LPTIM1</name>
+      <description>Low power timer</description>
+      <groupName>LPTIM1</groupName>
+      <baseAddress>0x40007C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>LPTIM1_DAC</name>
+        <description>LPTIM1, DAC global Interrupts</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>Interrupt and Status Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRM</name>
+              <description>Autoreload match</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROK</name>
+              <description>Autoreload match update OK</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <displayName>ICR</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMCF</name>
+              <description>Autoreload match Clear Flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKCF</name>
+              <description>Autoreload match update OK Clear Flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>Interrupt Enable Register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMIE</name>
+              <description>Autoreload matchInterrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKIE</name>
+              <description>Autoreload match update OK Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Configuration Register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PRELOAD</name>
+              <description>Registers update mode</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Clock prescaler</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control Register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RSTARE</name>
+              <description>Reset after read enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNTRST</name>
+              <description>Reset counter</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTSTRT</name>
+              <description>CNTSTRT</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SNGSTRT</name>
+              <description>LPTIM start in single mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>LPTIM Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <displayName>ARR</displayName>
+          <description>Autoreload Register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>Auto reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>Counter Register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>Counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USART1</name>
+      <description>Universal synchronous asynchronous receiver transmitter</description>
+      <groupName>USART</groupName>
+      <baseAddress>0x40013800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USART1</name>
+        <description>USART1 global Interrupt</description>
+        <value>27</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00C0</resetValue>
+          <fields>
+            <field>
+              <name>ABRRQ</name>
+              <description>Automate baudrate detection requeset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ABRE</name>
+              <description>Automate baudrate detection error flag</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABRF</name>
+              <description>Automate baudrate detection flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>CTS flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>Transmit data register empty</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TC</name>
+              <description>Transmission complete</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXNE</name>
+              <description>Read data register not empty</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IDLE</name>
+              <description>IDLE line detected</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ORE</name>
+              <description>Overrun error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>NE</name>
+              <description>Noise error flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FE</name>
+              <description>Framing error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Parity error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>Baud rate register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DIV_Mantissa</name>
+              <description>mantissa of USARTDIV</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>DIV_Fraction</name>
+              <description>fraction of USARTDIV</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>UE</name>
+              <description>USART enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>M</name>
+              <description>Word length</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKE</name>
+              <description>Wakeup method</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PCE</name>
+              <description>Parity control enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PS</name>
+              <description>Parity selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEIE</name>
+              <description>PE interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>TXE interrupt enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transmission complete interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>RXNE interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDLEIE</name>
+              <description>IDLE interrupt enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TE</name>
+              <description>Transmitter enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RE</name>
+              <description>Receiver enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RWU</name>
+              <description>Receiver wakeup</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <displayName>CR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>STOP bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock polarity</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock phase</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LBCL</name>
+              <description>Last bit clock pulse</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADD</name>
+              <description>Address of the USART node</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR3</name>
+          <displayName>CR3</displayName>
+          <description>Control register 3</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ABRMOD</name>
+              <description>Auto baudrate mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ABREN</name>
+              <description>Auto baudrate enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVER8</name>
+              <description>Oversampling mode</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIE</name>
+              <description>CTS interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSE</name>
+              <description>CTS enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTSE</name>
+              <description>RTS enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HDSEL</name>
+              <description>Half-duplex selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <groupName>IWDG</groupName>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>KR</name>
+          <displayName>KR</displayName>
+          <description>Key register (IWDG_KR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>Prescaler register (IWDG_PR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLR</name>
+          <displayName>RLR</displayName>
+          <description>Reload register (IWDG_RLR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000FFF</resetValue>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value update</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK_UP_TRG_COM</name>
+        <description>TIM1 Break, Update, Trigger and Commutation Interrupt</description>
+        <value>13</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Compare Interrupt</description>
+        <value>14</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>desc DIR</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CMS</name>
+              <description>desc CMS</description>
+              <msb>6</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xF8</resetMask>
+          <fields>
+            <field>
+              <name>CCPC</name>
+              <description>desc CCPC</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CCUS</name>
+              <description>desc CCUS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MMS</name>
+              <description>desc MMS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TI1S</name>
+              <description>desc TI1S</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1</name>
+              <description>desc OIS1</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1N</name>
+              <description>desc OIS1N</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2</name>
+              <description>desc OIS2</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2N</name>
+              <description>desc OIS2N</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3</name>
+              <description>desc OIS3</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3N</name>
+              <description>desc OIS3N</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>desc OIS4</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCR</name>
+          <description>desc SMCR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFF7</resetMask>
+          <fields>
+            <field>
+              <name>SMS</name>
+              <description>desc SMS</description>
+              <msb>2</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OCCS</name>
+              <description>desc OCCS</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TS</name>
+              <description>desc TS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MSM</name>
+              <description>desc MSM</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETF</name>
+              <description>desc ETF</description>
+              <msb>11</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETPS</name>
+              <description>desc ETPS</description>
+              <msb>13</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ECE</name>
+              <description>desc ECE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>desc ETP</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IE</name>
+              <description>desc CC2IE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IE</name>
+              <description>desc CC3IE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IE</name>
+              <description>desc CC4IE</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIE</name>
+              <description>desc COMIE</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>desc TIE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIE</name>
+              <description>desc BIE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IF</name>
+              <description>desc CC2IF</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IF</name>
+              <description>desc CC3IF</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IF</name>
+              <description>desc CC4IF</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIF</name>
+              <description>desc COMIF</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIF</name>
+              <description>desc TIF</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIF</name>
+              <description>desc BIF</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>desc CC2OF</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3OF</name>
+              <description>desc CC3OF</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>desc CC4OF</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IR</name>
+              <description>desc IC2IR</description>
+              <msb>17</msb>
+              <lsb>17</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IR</name>
+              <description>desc IC3IR</description>
+              <msb>18</msb>
+              <lsb>18</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IR</name>
+              <description>desc IC3IR</description>
+              <msb>19</msb>
+              <lsb>19</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IF</name>
+              <description>desc IC2IF</description>
+              <msb>21</msb>
+              <lsb>21</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IF</name>
+              <description>desc IC3IF</description>
+              <msb>22</msb>
+              <lsb>22</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IF</name>
+              <description>desc IC3IF</description>
+              <msb>23</msb>
+              <lsb>23</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC2G</name>
+              <description>desc CC2G</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC3G</name>
+              <description>desc CC3G</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC4G</name>
+              <description>desc CC4G</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>COMG</name>
+              <description>desc COMG</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TG</name>
+              <description>desc TG</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>desc BG</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1FE</name>
+              <description>desc OC1FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1CE</name>
+              <description>desc OC1CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2FE</name>
+              <description>desc OC2FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2PE</name>
+              <description>desc OC2PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2M</name>
+              <description>desc OC2M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>desc OC2CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2PSC</name>
+              <description>desc IC2PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>desc IC2F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_OUTPUT</name>
+          <description>desc CCMR2:OUTPUT</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3FE</name>
+              <description>desc OC3FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3PE</name>
+              <description>desc OC3PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3M</name>
+              <description>desc OC3M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3CE</name>
+              <description>desc OC3CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4FE</name>
+              <description>desc OC4FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4PE</name>
+              <description>desc OC4PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4M</name>
+              <description>desc OC4M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>desc OC4CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_INPUT</name>
+          <description>desc CCMR2:INPUT</description>
+          <alternateRegister>CCMR2_OUTPUT</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3PSC</name>
+              <description>desc IC3PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3F</name>
+              <description>desc IC3F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4PSC</name>
+              <description>desc IC4PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>desc IC4F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NE</name>
+              <description>desc CC1NE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2E</name>
+              <description>desc CC2E</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>desc CC2P</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NE</name>
+              <description>desc CC2NE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NP</name>
+              <description>desc CC2NP</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3E</name>
+              <description>desc CC3E</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3P</name>
+              <description>desc CC3P</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NE</name>
+              <description>desc CC3NE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NP</name>
+              <description>desc CC3NP</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4E</name>
+              <description>desc CC4E</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>desc CC4P</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCR</name>
+          <description>desc RCR</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>REP</name>
+              <description>desc REP</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR2</name>
+          <description>desc CCR2</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR2</name>
+              <description>desc CCR2</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR3</name>
+          <description>desc CCR3</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR3</name>
+              <description>desc CCR3</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR4</name>
+          <description>desc CCR4</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR4</name>
+              <description>desc CCR4</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <description>desc BDTR</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>DTG</name>
+              <description>desc DTG</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>desc LOCK</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSI</name>
+              <description>desc OSSI</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSR</name>
+              <description>desc OSSR</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKE</name>
+              <description>desc BKE</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKP</name>
+              <description>desc BKP</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>AOE</name>
+              <description>desc AOE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>desc MOE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM14</name>
+      <description>General purpose timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40002000</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM14</name>
+        <description>TIM14 global Interrupt</description>
+        <value>19</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OR</name>
+          <description>desc OR</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>TI1_RMP</name>
+              <description>desc TI1_RMP</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCFG</name>
+      <description>System configuration controller</description>
+      <groupName>SYSCFG</groupName>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>SYSCFG configuration register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>I2C_PB6_FMP</name>
+              <description>desc I2C_PB6_FMP</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PB4_FMP</name>
+              <description>desc I2C_PB4_FMP</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PB3_FMP</name>
+              <description>desc I2C_PB3_FMP</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PA2_FMP</name>
+              <description>desc I2C_PA2_FMP</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MEM_MODE</name>
+              <description>Memory mapping selection bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>SYSCFG configuration register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ETR_SRC_TIM1</name>
+              <description>TIM1 ETR source selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOCKUP_LOCK</name>
+              <description>Cortex-M0+ LOCKUP bit enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIO_ENS</name>
+          <description>desc GPIO_ENS</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>PC_ENS</name>
+              <description>desc PC_ENS</description>
+              <msb>17</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PB_ENS</name>
+              <description>desc PB_ENS</description>
+              <msb>15</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PA_ENS</name>
+              <description>desc PA_ENS</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>Flash</description>
+      <groupName>Flash</groupName>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>FLASH global Interrupt</description>
+        <value>3</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ACR</name>
+          <displayName>ACR</displayName>
+          <description>Access control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000600</resetValue>
+          <fields>
+            <field>
+              <name>LATENCY</name>
+              <description>Latency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>KEYR</name>
+          <displayName>KEYR</displayName>
+          <description>Flash key register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Flash key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTKEYR</name>
+          <displayName>OPTKEYR</displayName>
+          <description>Option byte key register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Option byte key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTVERR</name>
+              <description>Option and Engineering bits loading validity error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPERR</name>
+              <description>Write protected error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Flash control register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xC0000000</resetValue>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>FLASH_CR Lock</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTLOCK</name>
+              <description>Options Lock</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBL_LAUNCH</name>
+              <description>Force the option byte loading</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGSTRT</name>
+              <description>Flash main memory program start</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTSTRT</name>
+              <description>Option byte program start</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SER</name>
+              <description>Sector erase</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass erase</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Page erase</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PG</name>
+              <description>Programming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTR</name>
+          <displayName>OPTR</displayName>
+          <description>Flash option register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x4F55B0AA</resetValue>
+          <fields>
+            <field>
+              <name>NRST_MODE</name>
+              <description>NRST_MODE</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWD_MODE</name>
+              <description>SWD_MODE</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <description>Independent watchdog selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BORF_LEV</name>
+              <description>These bits contain the VDD supply level threshold that activates the reset</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>BOREN</name>
+              <description>BOR reset Level</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDKR</name>
+          <displayName>SDKR</displayName>
+          <description>Flash SDK address register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFE0001F</resetValue>
+          <fields>
+            <field>
+              <name>SDK_END</name>
+              <description>SDK area end address</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SDK_STRT</name>
+              <description>SDK area start address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BTCR</name>
+          <displayName>BTCR</displayName>
+          <description>FLASH boot control register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>NBOOT1</name>
+              <description>desc NBOOT1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT0</name>
+              <description>desc BOOT0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT_SIZE</name>
+              <description>desc BOOT_SIZE</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRPR</name>
+          <displayName>WRPR</displayName>
+          <description>Flash WRP address register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000FFFF</resetValue>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <description>WRP address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STCR</name>
+          <displayName>STCR</displayName>
+          <description>Flash sleep time config register</description>
+          <addressOffset>0x90</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00006400</resetValue>
+          <fields>
+            <field>
+              <name>SLEEP_TIME</name>
+              <description>FLash sleep time configuration(counter based on HSI_10M)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>SLEEP_EN</name>
+              <description>FLash sleep enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS0</name>
+          <displayName>TS0</displayName>
+          <description>Flash TS0 register</description>
+          <addressOffset>0x100</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS0</name>
+              <description>FLash TS0 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS1</name>
+          <displayName>TS1</displayName>
+          <description>Flash TS1 register</description>
+          <addressOffset>0x104</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000001B0</resetValue>
+          <fields>
+            <field>
+              <name>TS1</name>
+              <description>FLash TS1 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS2P</name>
+          <displayName>TS2P</displayName>
+          <description>Flash TS2P register</description>
+          <addressOffset>0x108</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS2P</name>
+              <description>FLash TS2P register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TPS3</name>
+          <displayName>TPS3</displayName>
+          <description>Flash TPS3 register</description>
+          <addressOffset>0x10C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000006C0</resetValue>
+          <fields>
+            <field>
+              <name>TPS3</name>
+              <description>FLash TPS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS3</name>
+          <displayName>TS3</displayName>
+          <description>Flash TS3 register</description>
+          <addressOffset>0x110</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS3</name>
+              <description>FLash TS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERTPE</name>
+          <displayName>PERTPE</displayName>
+          <description>Flash PERTPE register</description>
+          <addressOffset>0x114</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>PERTPE</name>
+              <description>FLash PERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMERTPE</name>
+          <displayName>SMERTPE</displayName>
+          <description>Flash SMERTPE register</description>
+          <addressOffset>0x118</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>SMERTPE</name>
+              <description>FLash SMERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGTPE</name>
+          <displayName>PRGTPE</displayName>
+          <description>Flash PRGTPE register</description>
+          <addressOffset>0x11C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00005DC0</resetValue>
+          <fields>
+            <field>
+              <name>PRGTPE</name>
+              <description>FLash PRGTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRETPE</name>
+          <displayName>PRETPE</displayName>
+          <description>Flash PRETPE register</description>
+          <addressOffset>0x120</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000012C0</resetValue>
+          <fields>
+            <field>
+              <name>PRETPE</name>
+              <description>FLash PRETPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>14</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <description>CRC calculation unit</description>
+      <groupName>CRC</groupName>
+      <baseAddress>0x40023000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>Independent Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IDR</name>
+              <description>Independent Data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RESET</name>
+              <description>Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SPI1</name>
+      <description>Serial peripheral interface</description>
+      <groupName>SPI</groupName>
+      <baseAddress>0x40013000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SPI1</name>
+        <description>SPI1 global Interrupt</description>
+        <value>25</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>CPHA</name>
+              <description>desc CPHA</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>desc CPOL</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MSTR</name>
+              <description>desc MSTR</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BR</name>
+              <description>desc BR</description>
+              <msb>5</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SPE</name>
+              <description>desc SPE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSBFIRST</name>
+              <description>desc LSBFIRST</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SSI</name>
+              <description>desc SSI</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SSM</name>
+              <description>desc SSM</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXONLY</name>
+              <description>desc RXONLY</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DDF</name>
+              <description>desc DDF</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIDIOE</name>
+              <description>desc BIDIOE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIDIMODE</name>
+              <description>desc BIDIMODE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>SSOE</name>
+              <description>desc SSOE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>desc ERRIE</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>desc RXNEIE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>desc TXEIE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DS</name>
+              <description>desc DS</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SLVFM</name>
+              <description>desc SLVFM</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x2</resetValue>
+          <fields>
+            <field>
+              <name>RXNE</name>
+              <description>desc RXNE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>desc TXE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MODF</name>
+              <description>desc MODF</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>desc OVR</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BSY</name>
+              <description>desc BSY</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FRLVL</name>
+              <description>desc FRLVL</description>
+              <msb>10</msb>
+              <lsb>9</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FTLVL</name>
+              <description>desc FTLVL</description>
+              <msb>12</msb>
+              <lsb>11</lsb>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <description>desc DR</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>desc DR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>I2C</name>
+      <description>Inter integrated circuit</description>
+      <groupName>I2C</groupName>
+      <baseAddress>0x40005400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>I2C1</name>
+        <description>I2C1 global Interrupt</description>
+        <value>23</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POS</name>
+              <description>Acknowledge/PEC Position (for datareception)</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACK</name>
+              <description>Acknowledge enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STOP</name>
+              <description>Stop generation</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>Start generation</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NOSTRETCH</name>
+              <description>Clock stretching disable (Slavemode)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENGC</name>
+              <description>General call enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Peripheral enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <displayName>CR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ITBUFEN</name>
+              <description>Buffer interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ITEVTEN</name>
+              <description>Event interrupt enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ITERREN</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREQ</name>
+              <description>Peripheral clock frequency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OAR1</name>
+          <displayName>OAR1</displayName>
+          <description>Own address register 1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ADD</name>
+              <description>Interface address</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>8-bit data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR1</name>
+          <displayName>SR1</displayName>
+          <description>Status register 1</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>OVR</name>
+              <description>Overrun/Underrun</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>AF</name>
+              <description>Acknowledge failure</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARLO</name>
+              <description>Arbitration lost (mastermode)</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TxE</name>
+              <description>Data register empty(transmitters)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RxNE</name>
+              <description>Data register not empty(receivers)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STOPF</name>
+              <description>Stop detection (slavemode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTF</name>
+              <description>Byte transfer finished</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address sent (master mode)/matched(slave mode)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Start bit (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR2</name>
+          <displayName>SR2</displayName>
+          <description>Status register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>GENCALL</name>
+              <description>General call address (Slavemode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRA</name>
+              <description>Transmitter/receiver</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Bus busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSL</name>
+              <description>Master/slave</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <displayName>CCR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>F_S</name>
+              <description>I2C master mode selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DUTY</name>
+              <description>Fast mode duty cycle</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCR</name>
+              <description>Clock control register in Fast/Standardmode (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TRISE</name>
+          <displayName>TRISE</displayName>
+          <description>TRISE register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0002</resetValue>
+          <fields>
+            <field>
+              <name>TRISE</name>
+              <description>Maximum rise time in Fast/Standard mode(Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBGMCU</name>
+      <description>Debug support</description>
+      <groupName>DBGMCU</groupName>
+      <baseAddress>0x40015800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>IDCODE</name>
+          <displayName>IDCODE</displayName>
+          <description>MCU Device ID Code Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>REV_ID</name>
+              <description>REV_ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Debug MCU Configuration Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_STOP</name>
+              <description>Debug Stop Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ1</name>
+          <displayName>APB_FZ1</displayName>
+          <description>APB Freeze Register1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_LPTIM_STOP</name>
+              <description>Debug LPTIM stopped when Core ishalted</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ2</name>
+          <displayName>APB_FZ2</displayName>
+          <description>APB Freeze Register2</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_TIM14_STOP</name>
+              <description>Debug TIM 14 stopped whenCore is halted</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBG_TIMER1_STOP</name>
+              <description>Debug Timer 1 stopped when Core ishalted</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/MS32C012xx.svd
+++ b/svd/MS32C012xx.svd
@@ -1,0 +1,6260 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>MS</vendor>
+  <vendorID>MS</vendorID>
+  <name>MS32Cxxx_DFP</name>  <!-- name of part-->
+  <series>MS32C</series>
+  <version>1.0.0</version>
+  <description>Arm 32-bit Cortex-M0+ Microcontroller based device, CPU clock up to 24 MHz.</description>
+  <cpu>    <!-- details about the cpu embedded in the device -->
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <addressUnitBits>8</addressUnitBits>  <!-- byte addressable memory -->
+  <width>32</width>  <!-- bus width is 32 bits -->  <!-- default settings implicitly inherited by subsequent sections -->
+  <size>32</size>  <!-- this is the default size (number of bits) of all peripherals and register that do not define "size" themselves -->
+  <access>read-write</access>  <!-- default access permission for all subsequent registers -->
+  <resetValue>0x00000000</resetValue>  <!-- by default all bits of the registers are initialized to 0 on reset -->
+  <resetMask>0xFFFFFFFF</resetMask>  <!-- by default all 32Bits of the registers are used -->
+  <peripherals>
+    <peripheral>
+      <name>ADC</name>
+      <description>Analog to Digital Converter</description>
+      <groupName>ADC</groupName>
+      <baseAddress>0x40012400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC_COMP</name>
+        <description>ADC and COMP Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>ADC interrupt and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWD</name>
+              <description>ADC analog watchdog flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>ADC group regular overrun flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSEQ</name>
+              <description>ADC group regular end of sequence conversions flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOC</name>
+              <description>ADC group regular end of unitary conversion flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSMP</name>
+              <description>ADC group regular end of sampling flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>ADC interrupt enable register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWDIE</name>
+              <description>ADC analog watchdog interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVRIE</name>
+              <description>ADC group regular overrun interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSEQIE</name>
+              <description>ADC group regular end of sequence conversions interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOCIE</name>
+              <description>ADC group regular end of unitary conversion interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOSMPIE</name>
+              <description>ADC group regular end of sampling interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>ADC control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ADCAL</name>
+              <description>ADC group regular conversion calibration</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VERBUFF_SEL</name>
+              <description>desc VERBUFF_SEL</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>VREF_BUFFERE</name>
+              <description>desc VREF_BUFFERE</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADSTP</name>
+              <description>ADC group regular conversion stop</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADSTART</name>
+              <description>ADC group regular conversion start</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDIS</name>
+              <description>ADC enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADEN</name>
+              <description>ADC enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>ADC configuration register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWDCH</name>
+              <description>ADC analog watchdog monitored channel selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AWDEN</name>
+              <description>ADC analog watchdog enable on scope ADC group regular</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDSGL</name>
+              <description>ADC analog watchdog monitoring a single channel or all channels</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DISCEN</name>
+              <description>ADC group regular sequencer discontinuous mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAIT</name>
+              <description>Wait conversion mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CONT</name>
+              <description>ADC group regular continuous conversion mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVRMOD</name>
+              <description>ADC group regular overrun configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTEN</name>
+              <description>ADC group regular external trigger polarity</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTSEL</name>
+              <description>ADC group regular external trigger source</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>ALIGN</name>
+              <description>ADC data alignement</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>ADC data resolution</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCANDIR</name>
+              <description>Scan sequence direction</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>ADC configuration register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CKMODE</name>
+              <description>ADC clock mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMPR</name>
+          <displayName>SMPR</displayName>
+          <description>ADC sampling time register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SMP</name>
+              <description>Sampling time selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TR</name>
+          <displayName>TR</displayName>
+          <description>ADC analog watchdog 1 threshold register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0FFF0000</resetValue>
+          <fields>
+            <field>
+              <name>HT</name>
+              <description>ADC analog watchdog threshold high</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LT</name>
+              <description>ADC analog watchdog threshold low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSELR</name>
+          <displayName>CHSELR</displayName>
+          <description>ADC group regular sequencer register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0FFF0000</resetValue>
+          <fields>
+            <field>
+              <name>CHSEL9</name>
+              <description>Channel-9 selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL8</name>
+              <description>Channel-8 selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL7</name>
+              <description>Channel-7 selection</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL6</name>
+              <description>Channel-6 selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL5</name>
+              <description>Channel-5 selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL4</name>
+              <description>Channel-4 selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL3</name>
+              <description>Channel-3 selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL2</name>
+              <description>Channel-2 selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL1</name>
+              <description>Channel-1 selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CHSEL0</name>
+              <description>Channel-0 selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>ADC group regular data register</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>ADC group regular conversion data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCSR</name>
+          <displayName>CCSR</displayName>
+          <description>ADC calibration configuration and status register</description>
+          <addressOffset>0x44</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CALON</name>
+              <description>Calibration flag</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CALSUC</name>
+              <description>desc CALSUC</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OFFSUC</name>
+              <description>desc OFFSUC</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALSET</name>
+              <description>Calibration factor selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALBYP</name>
+              <description>desc CALBYP</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALSMP</name>
+              <description>Calibration sample time selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CALSEL</name>
+              <description>Calibration contents selection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <displayName>CCR</displayName>
+          <description>ADC common configuration register</description>
+          <addressOffset>0x308</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature sensor enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VREFEN</name>
+              <description>VREFINT enable</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>COMP1</name>
+      <description>Comparator 1</description>
+      <groupName>COMP</groupName>
+      <baseAddress>0x40010200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC_COMP</name>
+        <description>ADC and COMP Interrupts</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>COMP control and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP_OUT</name>
+              <description>Comparator output status</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCSEL</name>
+              <description>VCSEL</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCDIV_EN</name>
+              <description>VCDIV_EN</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VCDIV</name>
+              <description>VCDIV</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>POLARITY</name>
+              <description>Comparator polarity selector</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMODE</name>
+              <description>Comparator non-inverting input selector for window mode</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INNSEL</name>
+              <description>desc INNSEL</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>COMP enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FR</name>
+          <displayName>FR</displayName>
+          <description>Comparator Filter register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FLTCNT1</name>
+              <description>Comparator filter and counter</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FLTEN1</name>
+              <description>Filter enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>COMP2</name>
+      <description>Comparator2</description>
+      <groupName>COMP</groupName>
+      <baseAddress>0x40010210</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC_COMP</name>
+        <description>ADC and COMP Interrupt</description>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>COMP control and status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP_OUT</name>
+              <description>Comparator output status</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLARITY</name>
+              <description>Comparator polarity selector</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INPSEL</name>
+              <description>Comparator signal selector for non-inverting input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INMSEL</name>
+              <description>Comparator signal selector for inverting input INM</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>COMP enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FR</name>
+          <displayName>FR</displayName>
+          <description>Comparator Filter register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FLTCNT2</name>
+              <description>Comparator filter and counter</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FLTEN2</name>
+              <description>Filter enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <groupName>RCC</groupName>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RCC</name>
+        <description>RCC global Interrupt</description>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>HSEEN</name>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIDIV</name>
+              <description>HSI16 clock division factor</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>HSI16 clock ready flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSION</name>
+              <description>HSI16 clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICSCR</name>
+          <displayName>ICSCR</displayName>
+          <description>Internal clock sources calibration register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x10000000</resetValue>
+          <fields>
+            <field>
+              <name>LSI_STARTUP</name>
+              <description>LSI startup time</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSI_TRIM</name>
+              <description>LSI clock trimming</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_FS</name>
+              <description>HSI frequency selection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSI_TRIM</name>
+              <description>HSI clock trimming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Clock configuration register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MCOPRE</name>
+              <description>Microcontroller clock output prescaler</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MCOSEL</name>
+              <description>Microcontroller clock output</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PPRE</name>
+              <description>APB prescaler</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HPRE</name>
+              <description>AHB prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SWS</name>
+              <description>System clock switch status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SW</name>
+              <description>System clock switch</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECSCR</name>
+          <displayName>ECSCR</displayName>
+          <description>External clock source control register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSE_STARTUP</name>
+              <description>desc LSE_STARTUP</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSE_DRIVER</name>
+              <description>desc LSE_DRIVER</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIER</name>
+          <displayName>CIER</displayName>
+          <description>Clock interrupt enable register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>HSIRDYIE</name>
+              <description>HSI ready interrupt enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYIE</name>
+              <description>LSE ready interrupt enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYIE</name>
+              <description>LSI ready interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CIFR</name>
+          <displayName>CIFR</displayName>
+          <description>Clock interrupt flag register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSF</name>
+              <description>LSE clock secure system interrupt flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYF</name>
+              <description>HSI ready interrupt flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYF</name>
+              <description>LSE ready interrupt flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYF</name>
+              <description>LSI ready interrupt flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CICR</name>
+          <displayName>CICR</displayName>
+          <description>Clock interrupt clear register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSECSSC</name>
+              <description>LSE clock secure system interrupt flag clear</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HSIRDYC</name>
+              <description>HSI ready interrupt clear</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDYC</name>
+              <description>LSE ready interrupt clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDYC</name>
+              <description>LSI ready interrupt clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPRSTR</name>
+          <displayName>IOPRSTR</displayName>
+          <description>GPIO reset register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCRST</name>
+              <description>I/O port C reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBRST</name>
+              <description>I/O port B reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOARST</name>
+              <description>I/O port A reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBRSTR</name>
+          <displayName>AHBRSTR</displayName>
+          <description>AHB peripheral reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCRST</name>
+              <description>CRC reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHRST</name>
+              <description>FLASH reset</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR1</name>
+          <displayName>APBRSTR1</displayName>
+          <description>APB peripheral reset register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMRST</name>
+              <description>Low Power Timer reset</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRST</name>
+              <description>Power interface reset</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGRST</name>
+              <description>Debug support reset</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2CRST</name>
+              <description>I2C reset</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBRSTR2</name>
+          <displayName>APBRSTR2</displayName>
+          <description>APB peripheral reset register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP2RST</name>
+              <description>COMP2 reset</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1RST</name>
+              <description>COMP1 reset</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADCRST</name>
+              <description>ADC reset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14RST</name>
+              <description>TIM14 reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USART1RST</name>
+              <description>USART1 reset</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPI1RST</name>
+              <description>SPI1 reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1RST</name>
+              <description>TIM1 timer reset</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGRST</name>
+              <description>SYSCFG and COMP reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOPENR</name>
+          <displayName>IOPENR</displayName>
+          <description>GPIO clock enable register</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GPIOCEN</name>
+              <description>I/O port C clock enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOBEN</name>
+              <description>I/O port B clock enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPIOAEN</name>
+              <description>I/O port A clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBENR</name>
+          <displayName>AHBENR</displayName>
+          <description>AHB peripheral clock enable register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CRCEN</name>
+              <description>CRC clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAMEN</name>
+              <description>SRAM memory interface clock enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLASHEN</name>
+              <description>Flash memory interface clock enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR1</name>
+          <displayName>APBENR1</displayName>
+          <description>APB peripheral clock enable register 1</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIMEN</name>
+              <description>LPTIM clock enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWREN</name>
+              <description>Power interface clock enable</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGEN</name>
+              <description>Debug support clock enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2CEN</name>
+              <description>I2C clock enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBENR2</name>
+          <displayName>APBENR2</displayName>
+          <description>APB peripheral clock enable register 2</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>COMP2EN</name>
+              <description>COMP2 clock enable</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1EN</name>
+              <description>COMP1 clock enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADCEN</name>
+              <description>ADC clock enable</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM14EN</name>
+              <description>TIM14 clock enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USART1EN</name>
+              <description>USART1 clock enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPI1EN</name>
+              <description>SPI1 clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>TIM1 timer clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCFGEN</name>
+              <description>SYSCFG, COMP and VREFBUF clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCIPR</name>
+          <displayName>CCIPR</displayName>
+          <description>Peripherals independent clock configuration register</description>
+          <addressOffset>0x54</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LPTIM1SEL</name>
+              <description>LPTIM1 clock source selection</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>COMP2SEL</name>
+              <description>COMP2 clock source selection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1SEL</name>
+              <description>COMP1 clock source selection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDCR</name>
+          <displayName>BDCR</displayName>
+          <description>RTC domain control register</description>
+          <addressOffset>0x5C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LSCOSEL</name>
+              <description>Low-speed clock output selection</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSCOEN</name>
+              <description>Low-speed clock output (LSCO) enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSD</name>
+              <description>LSE CSS detect</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSECSSON</name>
+              <description>LSE CSS enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEBYP</name>
+              <description>LSE oscillator bypass</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSERDY</name>
+              <description>LSE oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSEON</name>
+              <description>LSE oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>Control/status register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>Independent window watchdog reset flag</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Software reset flag</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PWRRSTF</name>
+              <description>BOR or POR/PDR flag</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>Pin reset flag</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBLRSTF</name>
+              <description>Option byte loader reset flag</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RMVF</name>
+              <description>Remove reset flags</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINRST_FLTDIS</name>
+              <description>desc PINRST_FLTDIS</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSIRDY</name>
+              <description>LSI oscillator ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSION</name>
+              <description>LSI oscillator enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <groupName>PWR</groupName>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Power control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00030000</resetValue>
+          <fields>
+            <field>
+              <name>HSION_CTRL</name>
+              <description>HSI open time control</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SRAM_RETV</name>
+              <description>SRAM retention voltage control</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>LPR</name>
+              <description>Low-power run</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FLS_SLPTIME</name>
+              <description>Flash wait time after wakeup from the stop mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+                        <field>
+              <name>BIAS_CR_SEL</name>
+              <description>MR Bias current selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CR</name>
+              <description>MR Bias current</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+              </registers>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD7</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD6</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD5</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD4</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD3</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD2</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID7</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID6</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID5</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID4</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID3</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID2</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD7</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD6</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD5</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD4</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD3</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD2</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL7</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL6</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL5</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL4</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL3</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL2</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR7</name>
+              <description>Port Reset bit</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Port Reset bit</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Port Reset bit</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Port Reset bit</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Port Reset bit</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Port Reset bit</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x50000400</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>GPIOC</name>
+      <description>General-purpose I/Os</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x50000800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>MODER</name>
+          <displayName>MODER</displayName>
+          <description>GPIO port mode register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xEBFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>MODE1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MODE0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OTYPER</name>
+          <displayName>OTYPER</displayName>
+          <description>GPIO port output type register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OT1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OT0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSPEEDR</name>
+          <displayName>OSPEEDR</displayName>
+          <description>GPIO port output speed register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            <field>
+              <name>OSPEED1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>OSPEED0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PUPDR</name>
+          <displayName>PUPDR</displayName>
+          <description>GPIO port pull-up/pull-down register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x24000000</resetValue>
+          <fields>
+            <field>
+              <name>PUPD1</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PUPD0</name>
+              <description>Port x configuration bits (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>GPIO port input data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ID1</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ID0</name>
+              <description>Port input data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ODR</name>
+          <displayName>ODR</displayName>
+          <description>GPIO port output data register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OD1</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OD0</name>
+              <description>Port output data (y = 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSRR</name>
+          <displayName>BSRR</displayName>
+          <description>GPIO port bit set/reset register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port x reset bit y (y = 0..15)</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BS0</name>
+              <description>Port x set bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>GPIO port configuration lock register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCKK</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LCK0</name>
+              <description>Port x lock bit y (y= 0..15)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFRL</name>
+          <displayName>AFRL</displayName>
+          <description>GPIO alternate function low register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFSEL1</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>AFSEL0</name>
+              <description>Alternate function selection for port x bit y (y = 0..7)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>port bit reset register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR1</name>
+              <description>Port Reset bit</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Port Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>External interrupt/event controller</description>
+      <groupName>EXTI</groupName>
+      <baseAddress>0x40021800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EXTI0_1</name>
+        <description>EXTI Line 0 and 1 Interrupt</description>
+        <value>5</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI2_3</name>
+        <description>EXTI Line 2 and 3 Interrupt</description>
+        <value>6</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI4_15</name>
+        <description>EXTI Line 4 to 15 Interrupt</description>
+        <value>7</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>RTSR</name>
+          <displayName>RTSR</displayName>
+          <description>EXTI rising trigger selection register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RT18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RT0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTSR</name>
+          <displayName>FTSR</displayName>
+          <description>EXTI falling trigger selection register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FT18</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT17</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT7</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT6</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT5</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT4</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT3</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT2</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT1</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FT0</name>
+              <description>Falling trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIER</name>
+          <displayName>SWIER</displayName>
+          <description>EXTI software interrupt event register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SWI18</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI17</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI7</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI6</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI5</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI4</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI3</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI2</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI1</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWI0</name>
+              <description>Rising trigger event configuration bit of Configurable Event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>EXTI pending register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR18</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR17</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR7</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR6</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR5</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR4</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR3</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR2</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR1</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PR0</name>
+              <description>configurable event inputs x rising edge Pending bit.</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <displayName>EXTICR1</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI3</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>EXTI0</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <displayName>EXTICR2</displayName>
+          <description>EXTI external interrupt selection register</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI7</name>
+              <description>GPIO port selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>GPIO port selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>GPIO port selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTI4</name>
+              <description>GPIO port selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <displayName>IMR</displayName>
+          <description>EXTI CPU wakeup with interrupt mask register</description>
+          <addressOffset>0x80</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFF80000</resetValue>
+          <fields>
+            <field>
+              <name>IM29</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM18</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM17</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM7</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM6</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM5</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM4</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM3</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM2</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM1</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IM0</name>
+              <description>CPU wakeup with interrupt mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMR</name>
+          <displayName>EMR</displayName>
+          <description>EXTI CPU wakeup with event mask register</description>
+          <addressOffset>0x84</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EM29</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM18</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM17</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM7</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM6</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM5</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM4</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM3</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM2</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM1</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EM0</name>
+              <description>CPU wakeup with event mask on event input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>LPTIM1</name>
+      <description>Low power timer</description>
+      <groupName>LPTIM1</groupName>
+      <baseAddress>0x40007C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>LPTIM1_DAC</name>
+        <description>LPTIM1, DAC global Interrupts</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ISR</name>
+          <displayName>ISR</displayName>
+          <description>Interrupt and Status Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRM</name>
+              <description>Autoreload match</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROK</name>
+              <description>Autoreload match update OK</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <displayName>ICR</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMCF</name>
+              <description>Autoreload match Clear Flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKCF</name>
+              <description>Autoreload match update OK Clear Flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IER</name>
+          <displayName>IER</displayName>
+          <description>Interrupt Enable Register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ARRMIE</name>
+              <description>Autoreload matchInterrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARROKIE</name>
+              <description>Autoreload match update OK Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Configuration Register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PRELOAD</name>
+              <description>Registers update mode</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Clock prescaler</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control Register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RSTARE</name>
+              <description>Reset after read enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNTRST</name>
+              <description>Reset counter</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTSTRT</name>
+              <description>CNTSTRT</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SNGSTRT</name>
+              <description>LPTIM start in single mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>LPTIM Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <displayName>ARR</displayName>
+          <description>Autoreload Register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>Auto reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>Counter Register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>Counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USART1</name>
+      <description>Universal synchronous asynchronous receiver transmitter</description>
+      <groupName>USART</groupName>
+      <baseAddress>0x40013800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USART1</name>
+        <description>USART1 global Interrupt</description>
+        <value>27</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00C0</resetValue>
+          <fields>
+            <field>
+              <name>ABRRQ</name>
+              <description>Automate baudrate detection requeset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ABRE</name>
+              <description>Automate baudrate detection error flag</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABRF</name>
+              <description>Automate baudrate detection flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>CTS flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>Transmit data register empty</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TC</name>
+              <description>Transmission complete</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXNE</name>
+              <description>Read data register not empty</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IDLE</name>
+              <description>IDLE line detected</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ORE</name>
+              <description>Overrun error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>NE</name>
+              <description>Noise error flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FE</name>
+              <description>Framing error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Parity error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>Baud rate register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DIV_Mantissa</name>
+              <description>mantissa of USARTDIV</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>DIV_Fraction</name>
+              <description>fraction of USARTDIV</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>UE</name>
+              <description>USART enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>M</name>
+              <description>Word length</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKE</name>
+              <description>Wakeup method</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PCE</name>
+              <description>Parity control enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PS</name>
+              <description>Parity selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEIE</name>
+              <description>PE interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>TXE interrupt enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transmission complete interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>RXNE interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDLEIE</name>
+              <description>IDLE interrupt enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TE</name>
+              <description>Transmitter enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RE</name>
+              <description>Receiver enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RWU</name>
+              <description>Receiver wakeup</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <displayName>CR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>STOP bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock polarity</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock phase</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LBCL</name>
+              <description>Last bit clock pulse</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADD</name>
+              <description>Address of the USART node</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR3</name>
+          <displayName>CR3</displayName>
+          <description>Control register 3</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ABRMOD</name>
+              <description>Auto baudrate mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ABREN</name>
+              <description>Auto baudrate enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVER8</name>
+              <description>Oversampling mode</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIE</name>
+              <description>CTS interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSE</name>
+              <description>CTS enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTSE</name>
+              <description>RTS enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HDSEL</name>
+              <description>Half-duplex selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <groupName>IWDG</groupName>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>KR</name>
+          <displayName>KR</displayName>
+          <description>Key register (IWDG_KR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PR</name>
+          <displayName>PR</displayName>
+          <description>Prescaler register (IWDG_PR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLR</name>
+          <displayName>RLR</displayName>
+          <description>Reload register (IWDG_RLR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000FFF</resetValue>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value update</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK_UP_TRG_COM</name>
+        <description>TIM1 Break, Update, Trigger and Commutation Interrupt</description>
+        <value>13</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Compare Interrupt</description>
+        <value>14</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>desc DIR</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CMS</name>
+              <description>desc CMS</description>
+              <msb>6</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xF8</resetMask>
+          <fields>
+            <field>
+              <name>CCPC</name>
+              <description>desc CCPC</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CCUS</name>
+              <description>desc CCUS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MMS</name>
+              <description>desc MMS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TI1S</name>
+              <description>desc TI1S</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1</name>
+              <description>desc OIS1</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS1N</name>
+              <description>desc OIS1N</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2</name>
+              <description>desc OIS2</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS2N</name>
+              <description>desc OIS2N</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3</name>
+              <description>desc OIS3</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS3N</name>
+              <description>desc OIS3N</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>desc OIS4</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCR</name>
+          <description>desc SMCR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFF7</resetMask>
+          <fields>
+            <field>
+              <name>SMS</name>
+              <description>desc SMS</description>
+              <msb>2</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OCCS</name>
+              <description>desc OCCS</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TS</name>
+              <description>desc TS</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MSM</name>
+              <description>desc MSM</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETF</name>
+              <description>desc ETF</description>
+              <msb>11</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETPS</name>
+              <description>desc ETPS</description>
+              <msb>13</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ECE</name>
+              <description>desc ECE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>desc ETP</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IE</name>
+              <description>desc CC2IE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IE</name>
+              <description>desc CC3IE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IE</name>
+              <description>desc CC4IE</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIE</name>
+              <description>desc COMIE</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>desc TIE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIE</name>
+              <description>desc BIE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2IF</name>
+              <description>desc CC2IF</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3IF</name>
+              <description>desc CC3IF</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4IF</name>
+              <description>desc CC4IF</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>COMIF</name>
+              <description>desc COMIF</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIF</name>
+              <description>desc TIF</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIF</name>
+              <description>desc BIF</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>desc CC2OF</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3OF</name>
+              <description>desc CC3OF</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>desc CC4OF</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IR</name>
+              <description>desc IC2IR</description>
+              <msb>17</msb>
+              <lsb>17</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IR</name>
+              <description>desc IC3IR</description>
+              <msb>18</msb>
+              <lsb>18</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IR</name>
+              <description>desc IC3IR</description>
+              <msb>19</msb>
+              <lsb>19</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2IF</name>
+              <description>desc IC2IF</description>
+              <msb>21</msb>
+              <lsb>21</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3IF</name>
+              <description>desc IC3IF</description>
+              <msb>22</msb>
+              <lsb>22</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4IF</name>
+              <description>desc IC3IF</description>
+              <msb>23</msb>
+              <lsb>23</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC2G</name>
+              <description>desc CC2G</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC3G</name>
+              <description>desc CC3G</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC4G</name>
+              <description>desc CC4G</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>COMG</name>
+              <description>desc COMG</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TG</name>
+              <description>desc TG</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>desc BG</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1FE</name>
+              <description>desc OC1FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1CE</name>
+              <description>desc OC1CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2FE</name>
+              <description>desc OC2FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2PE</name>
+              <description>desc OC2PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2M</name>
+              <description>desc OC2M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>desc OC2CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2S</name>
+              <description>desc CC2S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2PSC</name>
+              <description>desc IC2PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>desc IC2F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_OUTPUT</name>
+          <description>desc CCMR2:OUTPUT</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3FE</name>
+              <description>desc OC3FE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3PE</name>
+              <description>desc OC3PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3M</name>
+              <description>desc OC3M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC3CE</name>
+              <description>desc OC3CE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4FE</name>
+              <description>desc OC4FE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4PE</name>
+              <description>desc OC4PE</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4M</name>
+              <description>desc OC4M</description>
+              <msb>14</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>desc OC4CE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR2_INPUT</name>
+          <description>desc CCMR2:INPUT</description>
+          <alternateRegister>CCMR2_OUTPUT</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC3S</name>
+              <description>desc CC3S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3PSC</name>
+              <description>desc IC3PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC3F</name>
+              <description>desc IC3F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4S</name>
+              <description>desc CC4S</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4PSC</name>
+              <description>desc IC4PSC</description>
+              <msb>11</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>desc IC4F</description>
+              <msb>15</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NE</name>
+              <description>desc CC1NE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2E</name>
+              <description>desc CC2E</description>
+              <msb>4</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>desc CC2P</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NE</name>
+              <description>desc CC2NE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2NP</name>
+              <description>desc CC2NP</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3E</name>
+              <description>desc CC3E</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3P</name>
+              <description>desc CC3P</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NE</name>
+              <description>desc CC3NE</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC3NP</name>
+              <description>desc CC3NP</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4E</name>
+              <description>desc CC4E</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>desc CC4P</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCR</name>
+          <description>desc RCR</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>REP</name>
+              <description>desc REP</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR2</name>
+          <description>desc CCR2</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR2</name>
+              <description>desc CCR2</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR3</name>
+          <description>desc CCR3</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR3</name>
+              <description>desc CCR3</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR4</name>
+          <description>desc CCR4</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR4</name>
+              <description>desc CCR4</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <description>desc BDTR</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>DTG</name>
+              <description>desc DTG</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>desc LOCK</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSI</name>
+              <description>desc OSSI</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OSSR</name>
+              <description>desc OSSR</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKE</name>
+              <description>desc BKE</description>
+              <msb>12</msb>
+              <lsb>12</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKP</name>
+              <description>desc BKP</description>
+              <msb>13</msb>
+              <lsb>13</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>AOE</name>
+              <description>desc AOE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>desc MOE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM14</name>
+      <description>General purpose timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40002000</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM14</name>
+        <description>TIM14 global Interrupt</description>
+        <value>19</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3FF</resetMask>
+          <fields>
+            <field>
+              <name>CEN</name>
+              <description>desc CEN</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>UDIS</name>
+              <description>desc UDIS</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>URS</name>
+              <description>desc URS</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OPM</name>
+              <description>desc OPM</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARPE</name>
+              <description>desc ARPE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>desc CKD</description>
+              <msb>9</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DIER</name>
+          <description>desc DIER</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F5F</resetMask>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>desc UIE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IE</name>
+              <description>desc CC1IE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x1E5F</resetMask>
+          <fields>
+            <field>
+              <name>UIF</name>
+              <description>desc UIF</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1IF</name>
+              <description>desc CC1IF</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1OF</name>
+              <description>desc CC1OF</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IR</name>
+              <description>desc IC1IR</description>
+              <msb>16</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1IF</name>
+              <description>desc IC1IF</description>
+              <msb>20</msb>
+              <lsb>20</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EGR</name>
+          <description>desc EGR</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x5F</resetMask>
+          <fields>
+            <field>
+              <name>UG</name>
+              <description>desc UG</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CC1G</name>
+              <description>Capture/Compare 1 Generation</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_OUTPUT</name>
+          <description>desc CCMR1:OUTPUT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1PE</name>
+              <description>desc OC1PE</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>OC1M</name>
+              <description>desc OC1M</description>
+              <msb>6</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCMR1_INPUT</name>
+          <description>desc CCMR1:INPUT</description>
+          <alternateRegister>CCMR1_OUTPUT</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CC1S</name>
+              <description>desc CC1S</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1PSC</name>
+              <description>desc IC1PSC</description>
+              <msb>3</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IC1F</name>
+              <description>desc IC1F</description>
+              <msb>7</msb>
+              <lsb>4</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <description>desc CCER</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0x3333</resetMask>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>desc CC1E</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1P</name>
+              <description>desc CC1P</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1NP</name>
+              <description>desc CC1NP</description>
+              <msb>3</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <description>desc CNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>desc CNT</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <description>desc PSC</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>desc PSC</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ARR</name>
+          <description>desc ARR</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0xFFFF</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>ARR</name>
+              <description>desc ARR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR1</name>
+          <description>desc CCR1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <resetMask>0xFFFF</resetMask>
+          <fields>
+            <field>
+              <name>CCR1</name>
+              <description>desc CCR1</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OR</name>
+          <description>desc OR</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>TI1_RMP</name>
+              <description>desc TI1_RMP</description>
+              <msb>1</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCFG</name>
+      <description>System configuration controller</description>
+      <groupName>SYSCFG</groupName>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>SYSCFG configuration register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>I2C_PB6_FMP</name>
+              <description>desc I2C_PB6_FMP</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PB4_FMP</name>
+              <description>desc I2C_PB4_FMP</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PB3_FMP</name>
+              <description>desc I2C_PB3_FMP</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2C_PA2_FMP</name>
+              <description>desc I2C_PA2_FMP</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MEM_MODE</name>
+              <description>Memory mapping selection bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>SYSCFG configuration register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ETR_SRC_TIM1</name>
+              <description>TIM1 ETR source selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOCKUP_LOCK</name>
+              <description>Cortex-M0+ LOCKUP bit enable bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIO_ENS</name>
+          <description>desc GPIO_ENS</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>PC_ENS</name>
+              <description>desc PC_ENS</description>
+              <msb>17</msb>
+              <lsb>16</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PB_ENS</name>
+              <description>desc PB_ENS</description>
+              <msb>15</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PA_ENS</name>
+              <description>desc PA_ENS</description>
+              <msb>7</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>Flash</description>
+      <groupName>Flash</groupName>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>FLASH global Interrupt</description>
+        <value>3</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>ACR</name>
+          <displayName>ACR</displayName>
+          <description>Access control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000600</resetValue>
+          <fields>
+            <field>
+              <name>LATENCY</name>
+              <description>Latency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>KEYR</name>
+          <displayName>KEYR</displayName>
+          <description>Flash key register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Flash key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTKEYR</name>
+          <displayName>OPTKEYR</displayName>
+          <description>Option byte key register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Option byte key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <displayName>SR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTVERR</name>
+              <description>Option and Engineering bits loading validity error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPERR</name>
+              <description>Write protected error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Flash control register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xC0000000</resetValue>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>FLASH_CR Lock</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTLOCK</name>
+              <description>Options Lock</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBL_LAUNCH</name>
+              <description>Force the option byte loading</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGSTRT</name>
+              <description>Flash main memory program start</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPTSTRT</name>
+              <description>Option byte program start</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SER</name>
+              <description>Sector erase</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass erase</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Page erase</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PG</name>
+              <description>Programming</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OPTR</name>
+          <displayName>OPTR</displayName>
+          <description>Flash option register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x4F55B0AA</resetValue>
+          <fields>
+            <field>
+              <name>NRST_MODE</name>
+              <description>NRST_MODE</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWD_MODE</name>
+              <description>SWD_MODE</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <description>Independent watchdog selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BORF_LEV</name>
+              <description>These bits contain the VDD supply level threshold that activates the reset</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>BOREN</name>
+              <description>BOR reset Level</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDKR</name>
+          <displayName>SDKR</displayName>
+          <description>Flash SDK address register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFE0001F</resetValue>
+          <fields>
+            <field>
+              <name>SDK_END</name>
+              <description>SDK area end address</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SDK_STRT</name>
+              <description>SDK area start address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BTCR</name>
+          <displayName>BTCR</displayName>
+          <description>FLASH boot control register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>NBOOT1</name>
+              <description>desc NBOOT1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT0</name>
+              <description>desc BOOT0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOOT_SIZE</name>
+              <description>desc BOOT_SIZE</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRPR</name>
+          <displayName>WRPR</displayName>
+          <description>Flash WRP address register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000FFFF</resetValue>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <description>WRP address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STCR</name>
+          <displayName>STCR</displayName>
+          <description>Flash sleep time config register</description>
+          <addressOffset>0x90</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00006400</resetValue>
+          <fields>
+            <field>
+              <name>SLEEP_TIME</name>
+              <description>FLash sleep time configuration(counter based on HSI_10M)</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>SLEEP_EN</name>
+              <description>FLash sleep enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS0</name>
+          <displayName>TS0</displayName>
+          <description>Flash TS0 register</description>
+          <addressOffset>0x100</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS0</name>
+              <description>FLash TS0 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS1</name>
+          <displayName>TS1</displayName>
+          <description>Flash TS1 register</description>
+          <addressOffset>0x104</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000001B0</resetValue>
+          <fields>
+            <field>
+              <name>TS1</name>
+              <description>FLash TS1 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS2P</name>
+          <displayName>TS2P</displayName>
+          <description>Flash TS2P register</description>
+          <addressOffset>0x108</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS2P</name>
+              <description>FLash TS2P register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TPS3</name>
+          <displayName>TPS3</displayName>
+          <description>Flash TPS3 register</description>
+          <addressOffset>0x10C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000006C0</resetValue>
+          <fields>
+            <field>
+              <name>TPS3</name>
+              <description>FLash TPS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TS3</name>
+          <displayName>TS3</displayName>
+          <description>Flash TS3 register</description>
+          <addressOffset>0x110</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000000B4</resetValue>
+          <fields>
+            <field>
+              <name>TS3</name>
+              <description>FLash TS3 register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERTPE</name>
+          <displayName>PERTPE</displayName>
+          <description>Flash PERTPE register</description>
+          <addressOffset>0x114</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>PERTPE</name>
+              <description>FLash PERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMERTPE</name>
+          <displayName>SMERTPE</displayName>
+          <description>Flash SMERTPE register</description>
+          <addressOffset>0x118</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00014820</resetValue>
+          <fields>
+            <field>
+              <name>SMERTPE</name>
+              <description>FLash SMERTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGTPE</name>
+          <displayName>PRGTPE</displayName>
+          <description>Flash PRGTPE register</description>
+          <addressOffset>0x11C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00005DC0</resetValue>
+          <fields>
+            <field>
+              <name>PRGTPE</name>
+              <description>FLash PRGTPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRETPE</name>
+          <displayName>PRETPE</displayName>
+          <description>Flash PRETPE register</description>
+          <addressOffset>0x120</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x000012C0</resetValue>
+          <fields>
+            <field>
+              <name>PRETPE</name>
+              <description>FLash PRETPE register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>14</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CRC</name>
+      <description>CRC calculation unit</description>
+      <groupName>CRC</groupName>
+      <baseAddress>0x40023000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDR</name>
+          <displayName>IDR</displayName>
+          <description>Independent Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IDR</name>
+              <description>Independent Data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RESET</name>
+              <description>Reset bit</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SPI1</name>
+      <description>Serial peripheral interface</description>
+      <groupName>SPI</groupName>
+      <baseAddress>0x40013000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SPI1</name>
+        <description>SPI1 global Interrupt</description>
+        <value>25</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <description>desc CR1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>CPHA</name>
+              <description>desc CPHA</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>desc CPOL</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MSTR</name>
+              <description>desc MSTR</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BR</name>
+              <description>desc BR</description>
+              <msb>5</msb>
+              <lsb>3</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SPE</name>
+              <description>desc SPE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LSBFIRST</name>
+              <description>desc LSBFIRST</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SSI</name>
+              <description>desc SSI</description>
+              <msb>8</msb>
+              <lsb>8</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SSM</name>
+              <description>desc SSM</description>
+              <msb>9</msb>
+              <lsb>9</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXONLY</name>
+              <description>desc RXONLY</description>
+              <msb>10</msb>
+              <lsb>10</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DDF</name>
+              <description>desc DDF</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIDIOE</name>
+              <description>desc BIDIOE</description>
+              <msb>14</msb>
+              <lsb>14</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BIDIMODE</name>
+              <description>desc BIDIMODE</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <description>desc CR2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>SSOE</name>
+              <description>desc SSOE</description>
+              <msb>2</msb>
+              <lsb>2</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>desc ERRIE</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>desc RXNEIE</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>desc TXEIE</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DS</name>
+              <description>desc DS</description>
+              <msb>11</msb>
+              <lsb>11</lsb>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SLVFM</name>
+              <description>desc SLVFM</description>
+              <msb>15</msb>
+              <lsb>15</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>desc SR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x2</resetValue>
+          <fields>
+            <field>
+              <name>RXNE</name>
+              <description>desc RXNE</description>
+              <msb>0</msb>
+              <lsb>0</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>desc TXE</description>
+              <msb>1</msb>
+              <lsb>1</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MODF</name>
+              <description>desc MODF</description>
+              <msb>5</msb>
+              <lsb>5</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>desc OVR</description>
+              <msb>6</msb>
+              <lsb>6</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BSY</name>
+              <description>desc BSY</description>
+              <msb>7</msb>
+              <lsb>7</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FRLVL</name>
+              <description>desc FRLVL</description>
+              <msb>10</msb>
+              <lsb>9</lsb>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FTLVL</name>
+              <description>desc FTLVL</description>
+              <msb>12</msb>
+              <lsb>11</lsb>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <description>desc DR</description>
+          <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>desc DR</description>
+              <msb>15</msb>
+              <lsb>0</lsb>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>I2C</name>
+      <description>Inter integrated circuit</description>
+      <groupName>I2C</groupName>
+      <baseAddress>0x40005400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>I2C1</name>
+        <description>I2C1 global Interrupt</description>
+        <value>23</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CR1</name>
+          <displayName>CR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POS</name>
+              <description>Acknowledge/PEC Position (for datareception)</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACK</name>
+              <description>Acknowledge enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STOP</name>
+              <description>Stop generation</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>Start generation</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NOSTRETCH</name>
+              <description>Clock stretching disable (Slavemode)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENGC</name>
+              <description>General call enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Peripheral enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR2</name>
+          <displayName>CR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ITBUFEN</name>
+              <description>Buffer interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ITEVTEN</name>
+              <description>Event interrupt enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ITERREN</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREQ</name>
+              <description>Peripheral clock frequency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OAR1</name>
+          <displayName>OAR1</displayName>
+          <description>Own address register 1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ADD</name>
+              <description>Interface address</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <displayName>DR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>8-bit data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR1</name>
+          <displayName>SR1</displayName>
+          <description>Status register 1</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>OVR</name>
+              <description>Overrun/Underrun</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>AF</name>
+              <description>Acknowledge failure</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ARLO</name>
+              <description>Arbitration lost (mastermode)</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TxE</name>
+              <description>Data register empty(transmitters)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RxNE</name>
+              <description>Data register not empty(receivers)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STOPF</name>
+              <description>Stop detection (slavemode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTF</name>
+              <description>Byte transfer finished</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address sent (master mode)/matched(slave mode)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Start bit (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR2</name>
+          <displayName>SR2</displayName>
+          <description>Status register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>GENCALL</name>
+              <description>General call address (Slavemode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRA</name>
+              <description>Transmitter/receiver</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Bus busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSL</name>
+              <description>Master/slave</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCR</name>
+          <displayName>CCR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>F_S</name>
+              <description>I2C master mode selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DUTY</name>
+              <description>Fast mode duty cycle</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCR</name>
+              <description>Clock control register in Fast/Standardmode (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TRISE</name>
+          <displayName>TRISE</displayName>
+          <description>TRISE register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0002</resetValue>
+          <fields>
+            <field>
+              <name>TRISE</name>
+              <description>Maximum rise time in Fast/Standard mode(Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBGMCU</name>
+      <description>Debug support</description>
+      <groupName>DBGMCU</groupName>
+      <baseAddress>0x40015800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>IDCODE</name>
+          <displayName>IDCODE</displayName>
+          <description>MCU Device ID Code Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>REV_ID</name>
+              <description>REV_ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>Debug MCU Configuration Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_STOP</name>
+              <description>Debug Stop Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ1</name>
+          <displayName>APB_FZ1</displayName>
+          <description>APB Freeze Register1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_LPTIM_STOP</name>
+              <description>Debug LPTIM stopped when Core ishalted</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APB_FZ2</name>
+          <displayName>APB_FZ2</displayName>
+          <description>APB Freeze Register2</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>DBG_TIM14_STOP</name>
+              <description>Debug TIM 14 stopped whenCore is halted</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBG_TIMER1_STOP</name>
+              <description>Debug Timer 1 stopped when Core ishalted</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>


### PR DESCRIPTION
- New die DIE001B: 17 peripherals, 13 interrupts (CMSIS/startup vector table; the SVD's 9-interrupt table is a stale MS32C001 copy), AF table from the datasheet (TIM1/TIM14/UART1/PWM1/ADC1/RCC/DBGMCU)
- New register YAMLs: uart_v1b, adc_v1c, pwm_v1, vref_v1, timer_v1b (TISEL@0x5C), rcc_ms32c001b (UART1EN/PWMEN/VREFBUFEN, no AHBRSTR), flash_ms32c001b (ERTPE, no ACR/BTCR), configbytes_ms32c001b (OB@0x1FFF0040), exti_v1b (lines 0-7 + 16/29), gpio_v1b (8 IO/port)
- series MS32C001B -> DIE001B; generic renamed MS32C001Bx4 with flash page 64B / sector 1KB (per MS107xx_16.FLM)
- Chip files renamed to base part numbers with package variants (MS32C001BF14 = BF14P7 + BF14U7)
- Pipeline: support MS32 chip prefixes; clean stale build output in gen