### PR TITLE
Add DAC trigger topology metadata

### DIFF
--- a/data/dies/DIE072/triggers.yaml
+++ b/data/dies/DIE072/triggers.yaml
@@ -1,0 +1,14 @@
+# Internal peripheral trigger topology from the PY32F07X reference manual.
+DAC:
+- signal: DAC_CHX_TRG0
+  source: TIM6_TRGO
+- signal: DAC_CHX_TRG1
+  source: TIM3_TRGO
+- signal: DAC_CHX_TRG2
+  source: TIM7_TRGO
+- signal: DAC_CHX_TRG3
+  source: TIM15_TRGO
+- signal: DAC_CHX_TRG4
+  source: TIM2_TRGO
+- signal: DAC_CHX_TRG6
+  source: EXTI9_TRG

--- a/py32-data-gen/src/main.rs
+++ b/py32-data-gen/src/main.rs
@@ -85,6 +85,10 @@ fn main() -> anyhow::Result<()> {
         String,
         HashMap<String, Vec<py32_data_serde::chip::core::peripheral::DmaChannel>>,
     > = HashMap::new();
+    let mut die_triggers: HashMap<
+        String,
+        HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Trigger>>,
+    > = HashMap::new();
     let mut processed_generics = HashSet::new();
 
     for name in &chip_meta_files {
@@ -215,10 +219,24 @@ fn main() -> anyhow::Result<()> {
             die_dma_requests.insert(die_name.clone(), peripheral_dma_reqs);
         }
 
+        if !die_triggers.contains_key(die_name) {
+            let trigger_path = data_dir.join(format!("dies/{}/triggers.yaml", die_name));
+            let triggers = if trigger_path.exists() {
+                let content = std::fs::read_to_string(&trigger_path)?;
+                let triggers = serde_yaml::from_str(&content)?;
+                validate_triggers(&triggers);
+                triggers
+            } else {
+                HashMap::new()
+            };
+            die_triggers.insert(die_name.clone(), triggers);
+        }
+
         // Build the Core
         let mut final_peripherals = Vec::new();
         let current_afs = die_afs.get(die_name).unwrap();
         let current_dma_reqs = die_dma_requests.get(die_name).unwrap();
+        let current_triggers = die_triggers.get(die_name).unwrap();
 
         for mut p in die_peripherals.get(die_name).unwrap().clone() {
             if !series.disabled_peripherals.contains(&p.name) {
@@ -229,6 +247,9 @@ fn main() -> anyhow::Result<()> {
                 // inject dma requests
                 if let Some(reqs) = current_dma_reqs.get(&p.name) {
                     p.dma_channels = reqs.clone();
+                }
+                if let Some(triggers) = current_triggers.get(&p.name) {
+                    p.triggers = triggers.clone();
                 }
 
                 // remove unused peripherals
@@ -308,4 +329,34 @@ fn main() -> anyhow::Result<()> {
     stopwatch.stop();
 
     Ok(())
+}
+
+fn validate_triggers(
+    peripherals: &HashMap<String, Vec<py32_data_serde::chip::core::peripheral::Trigger>>,
+) {
+    for (peripheral, triggers) in peripherals {
+        let mut trigger_sets: HashMap<&str, HashSet<&str>> = HashMap::new();
+
+        for trigger in triggers {
+            let signal = trigger
+                .signal
+                .trim_end_matches(|c: char| c.is_ascii_digit());
+            assert!(
+                signal.len() < trigger.signal.len()
+                    && trigger.signal[signal.len()..].parse::<u8>().is_ok(),
+                "trigger signal must end in a numeric selector value: {}:{}",
+                peripheral,
+                trigger.signal
+            );
+
+            let trigger_set = trigger_sets.entry(signal).or_default();
+            assert!(
+                trigger_set.insert(&trigger.source)
+                    && trigger.source == trigger.source.to_ascii_uppercase(),
+                "invalid or duplicate trigger source for {}: {}",
+                peripheral,
+                trigger.source
+            );
+        }
+    }
 }

--- a/py32-data-serde/src/lib.rs
+++ b/py32-data-serde/src/lib.rs
@@ -142,6 +142,8 @@ pub mod chip {
             pub interrupts: Option<Vec<peripheral::Interrupt>>, // TODO: This should just be a Vec
             #[serde(default, skip_serializing_if = "Vec::is_empty")]
             pub dma_channels: Vec<peripheral::DmaChannel>,
+            #[serde(default, skip_serializing_if = "Vec::is_empty")]
+            pub triggers: Vec<peripheral::Trigger>,
         }
 
         pub mod peripheral {
@@ -264,6 +266,14 @@ pub mod chip {
             pub struct Interrupt {
                 pub signal: String,
                 pub interrupt: String,
+            }
+
+            #[derive(
+                Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            pub struct Trigger {
+                pub signal: String,
+                pub source: String,
             }
 
             #[derive(

--- a/py32-metapac-gen/res/src/metadata.rs
+++ b/py32-metapac-gen/res/src/metadata.rs
@@ -175,6 +175,7 @@ pub struct Peripheral {
     pub rcc: Option<PeripheralRcc>,
     pub pins: &'static [PeripheralPin],
     pub dma_channels: &'static [PeripheralDmaChannel],
+    pub triggers: &'static [PeripheralTrigger],
     pub interrupts: &'static [PeripheralInterrupt],
 }
 
@@ -190,6 +191,12 @@ pub struct PeripheralRegisters {
 pub struct PeripheralInterrupt {
     pub signal: &'static str,
     pub interrupt: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PeripheralTrigger {
+    pub signal: &'static str,
+    pub source: &'static str,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/py32-metapac-gen/src/data.rs
+++ b/py32-metapac-gen/src/data.rs
@@ -380,6 +380,8 @@ pub struct Peripheral {
     #[serde(default)]
     pub dma_channels: Vec<PeripheralDmaChannel>,
     #[serde(default)]
+    pub triggers: Vec<PeripheralTrigger>,
+    #[serde(default)]
     pub interrupts: Vec<PeripheralInterrupt>,
 }
 
@@ -394,6 +396,7 @@ impl std::fmt::Debug for Peripheral {
             .field("rcc", &self.rcc)
             .field("pins", &self.pins)
             .field("dma_channels", &self.dma_channels)
+            .field("triggers", &self.triggers)
             .field("interrupts", &self.interrupts)
             .finish()
     }
@@ -403,6 +406,12 @@ impl std::fmt::Debug for Peripheral {
 pub struct PeripheralInterrupt {
     pub signal: String,
     pub interrupt: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
+pub struct PeripheralTrigger {
+    pub signal: String,
+    pub source: String,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]


### PR DESCRIPTION
to avoid hard coding within py32-hal