### PR TITLE
Add OPA registers

### DIFF
--- a/data/dies/DIE072/af.yaml
+++ b/data/dies/DIE072/af.yaml
@@ -838,3 +838,22 @@ DBGMCU:
   - af: 0
     pin: PA14
     signal: SWCLK
+OPA:
+  - pin: PA9
+    signal: VP1
+  - pin: PA10
+    signal: VN1
+  - pin: PA8
+    signal: VOUT1
+  - pin: PA7
+    signal: VP2
+  - pin: PA6
+    signal: VN2
+  - pin: PA5
+    signal: VOUT2
+  - pin: PB13
+    signal: VP3
+  - pin: PB12
+    signal: VN3
+  - pin: PB14
+    signal: VOUT3

--- a/data/dies/DIE072/peripherals.yaml
+++ b/data/dies/DIE072/peripherals.yaml
@@ -485,8 +485,8 @@
   address: 0x40010300
   registers:
     kind: opa
-    version: common
-    block: TODO
+    version: v1
+    block: OPA
   rcc:
     bus_clock: PCLK1
     kernel_clock: PCLK1

--- a/data/registers/opa_v1.yaml
+++ b/data/registers/opa_v1.yaml
@@ -1,0 +1,31 @@
+block/OPA:
+  description: Operational amplifiers
+  items:
+  - name: CR0
+    description: OPA output enable register
+    byte_offset: 48
+    fieldset: CR0
+  - name: CR1
+    description: OPA control register
+    byte_offset: 52
+    fieldset: CR1
+fieldset/CR0:
+  description: OPA output enable register
+  fields:
+  - name: OPAOEN1
+    description: OPAx output 1 enable. Routes the amplifier output to its dedicated pad. The output always reaches the ADC and COMP internally regardless of this bit.
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 3
+      stride: 5
+fieldset/CR1:
+  description: OPA control register
+  fields:
+  - name: EN
+    description: OPAx enable
+    bit_offset: 5
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1


### PR DESCRIPTION
For some chips there are only 2 OPA instead of 3, should this be a v1/v2 change? or just disable accessing the 3rd one in HAL? They are layout compatible