### PR TITLE
fix(registers): correct offsets, widths and names per reference manuals

### DIFF
--- a/data/dies/DIE072/peripherals.yaml
+++ b/data/dies/DIE072/peripherals.yaml
@@ -168,8 +168,11 @@
     bus_clock: PCLK1
     kernel_clock: PCLK1
     enable:
-      register: APBENR1
-      field: RTCAPBEN
+      register: BDCR
+      field: RTCEN
+    reset:
+      register: APBRSTR1
+      field: RTCAPBRST
   interrupts:
   - signal: GLOBAL
     interrupt: RTC

--- a/data/registers/adc_v1b.yaml
+++ b/data/registers/adc_v1b.yaml
@@ -166,12 +166,20 @@ fieldset/CCSR:
     description: Calibration sample time selection.
     bit_offset: 12
     bit_size: 2
+  - name: CALBYP
+    description: Calibration bypass.
+    bit_offset: 14
+    bit_size: 1
   - name: CALSET
     description: Calibration factor selection.
     bit_offset: 15
     bit_size: 1
-  - name: CALFAIL
-    description: Calibration fail flag.
+  - name: OFFSUC
+    description: Offset calibration success flag.
+    bit_offset: 29
+    bit_size: 1
+  - name: CALSUC
+    description: Calibration success flag (0 = calibration failed).
     bit_offset: 30
     bit_size: 1
   - name: CALON

--- a/data/registers/adc_v2.yaml
+++ b/data/registers/adc_v2.yaml
@@ -22,7 +22,7 @@ block/ADC:
     byte_offset: 16
     fieldset: SMPR2
   - name: SMPR3
-    description: desc SMPR2.
+    description: sample time register 3
     byte_offset: 20
     fieldset: SMPR3
   - name: JOFR
@@ -30,7 +30,7 @@ block/ADC:
     array:
       len: 4
       stride: 4
-    byte_offset: 20
+    byte_offset: 24
     fieldset: JOFR
   - name: HTR
     description: watchdog higher threshold register
@@ -274,7 +274,7 @@ fieldset/JSQR:
   - name: JL
     description: Injected sequence length
     bit_offset: 20
-    bit_size: 4
+    bit_size: 2
 fieldset/LTR:
   description: watchdog lower threshold register
   fields:
@@ -290,29 +290,29 @@ fieldset/SMPR1:
     bit_offset: 0
     bit_size: 3
     array:
-      len: 9
+      len: 4
       stride: 3
     enum: SAMPLE_TIME
 fieldset/SMPR2:
-  description: desc SMPR2.
+  description: sample time register 2
   fields:
   - name: SMP
     description:  Channel 10 sampling time selection
     bit_offset: 0
     bit_size: 3
     array:
-      len: 9
+      len: 10
       stride: 3
     enum: SAMPLE_TIME
 fieldset/SMPR3:
-  description: desc SMPR2.
+  description: sample time register 3
   fields:
   - name: SMP
     description:  Channel 0 sampling time selection
     bit_offset: 0
     bit_size: 3
     array:
-      len: 9
+      len: 10
       stride: 3
     enum: SAMPLE_TIME
 fieldset/SQR1:
@@ -430,8 +430,8 @@ enum/SAMPLE_TIME:
   - name: Cycles41_5
     description: 41.5 cycles
     value: 5
-  - name: Cycles71_5
-    description: 71.5 cycles
+  - name: Cycles134_5
+    description: 134.5 cycles
     value: 6
   - name: Cycles239_5
     description: 239.5 cycles

--- a/data/registers/configbytes_f072.yaml
+++ b/data/registers/configbytes_f072.yaml
@@ -14,8 +14,8 @@ block/CONFIGBYTES:
     byte_offset: 40
     fieldset: TSCAL
     access: Read
-  - name: TS_CAL_85C
-    description: Temperature sensor calibration value at 85°C.
+  - name: TS_CAL_105C
+    description: Temperature sensor calibration value at 105°C.
     byte_offset: 48
     fieldset: TSCAL
     access: Read
@@ -56,7 +56,7 @@ fieldset/HSI_TRIMMING:
   fields:
   - name: HSI_FS
     description: HSI frequency selection.
-    bit_offset: 13
+    bit_offset: 16
     bit_size: 3
   - name: HSI_TRIM
     description: HSI trimming value.

--- a/data/registers/dbgmcu_f072.yaml
+++ b/data/registers/dbgmcu_f072.yaml
@@ -105,4 +105,4 @@ fieldset/IDCODE:
   - name: REV_ID
     description: REV_ID.
     bit_offset: 0
-    bit_size: 31
+    bit_size: 32

--- a/data/registers/div_v1.yaml
+++ b/data/registers/div_v1.yaml
@@ -34,11 +34,11 @@ fieldset/SIGN:
 fieldset/STAT:
   description: Status register
   fields:
-  - name: DIV_END
+  - name: END
     description: Division end flag. Set when the division is finished. Reading QUOT/REMD before this flag is set returns the result of the last completed division.
     bit_offset: 0
     bit_size: 1
-  - name: DIV_ZERO
+  - name: ZERO
     description: Division by zero flag. Set when the divisor is 0. The operation ends immediately with QUOT and REMD both 0.
     bit_offset: 1
     bit_size: 1

--- a/data/registers/flash_f072.yaml
+++ b/data/registers/flash_f072.yaml
@@ -26,11 +26,11 @@ block/FLASH:
     byte_offset: 32
     access: Read
     fieldset: OPTR
-  - name: SDKR
-    description: desc SDKR.
+  - name: BORCR
+    description: Flash BORCR address register.
     byte_offset: 36
     access: Read
-    fieldset: SDKR
+    fieldset: BORCR
   - name: WRPR
     description: desc WRPR.
     byte_offset: 44
@@ -177,23 +177,15 @@ fieldset/PRGTPE:
     description: desc PRGTPE.
     bit_offset: 0
     bit_size: 16
-fieldset/SDKR:
-  description: desc SDKR.
+fieldset/BORCR:
+  description: Flash BORCR address register.
   fields:
-  - name: SDK_STRT
-    description: desc SDK_STRT.
-    bit_offset: 0
-    bit_size: 5
   - name: BOR_EN
-    description: desc BOR_EN.
+    description: BOR enable.
     bit_offset: 5
     bit_size: 1
-  - name: SDK_END
-    description: desc SDK_END.
-    bit_offset: 8
-    bit_size: 5
   - name: BOR_LEV
-    description: desc BOR_LEV.
+    description: BOR level.
     bit_offset: 13
     bit_size: 3
 fieldset/SMERTPE:

--- a/data/registers/i2c_v1.yaml
+++ b/data/registers/i2c_v1.yaml
@@ -13,6 +13,10 @@ block/I2C:
     description: Own address register 1.
     byte_offset: 8
     fieldset: OAR1
+  - name: OAR2
+    description: Own address register 2.
+    byte_offset: 12
+    fieldset: OAR2
   - name: DR
     description: Data register.
     byte_offset: 16
@@ -58,6 +62,18 @@ fieldset/CR1:
     description: Peripheral enable.
     bit_offset: 0
     bit_size: 1
+  - name: SMBUS
+    description: SMBus mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: SMBTYPE
+    description: SMBus type.
+    bit_offset: 3
+    bit_size: 1
+  - name: ENARP
+    description: ARP enable.
+    bit_offset: 4
+    bit_size: 1
   - name: ENPEC
     description: PEC enable.
     bit_offset: 5
@@ -90,6 +106,10 @@ fieldset/CR1:
   - name: PEC
     description: Packet error checking.
     bit_offset: 12
+    bit_size: 1
+  - name: ALERT
+    description: SMBus alert.
+    bit_offset: 13
     bit_size: 1
   - name: SWRST
     description: Software reset.
@@ -134,8 +154,27 @@ fieldset/OAR1:
   fields:
   - name: ADD
     description: Interface address.
+    bit_offset: 0
+    bit_size: 10
+  - name: ADDMODE
+    description: Addressing mode (slave mode).
+    bit_offset: 15
+    bit_size: 1
+fieldset/OAR2:
+  description: Own address register 2.
+  fields:
+  - name: ENDUAL
+    description: Dual addressing mode enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: ADD2
+    description: Interface address bits 7:1 in dual addressing mode.
     bit_offset: 1
     bit_size: 7
+  - name: OA2MSK
+    description: Own address 2 mask.
+    bit_offset: 8
+    bit_size: 3
 fieldset/SR1:
   description: Status register 1.
   fields:
@@ -150,6 +189,10 @@ fieldset/SR1:
   - name: BTF
     description: Byte transfer finished.
     bit_offset: 2
+    bit_size: 1
+  - name: ADD10
+    description: 10-bit header sent (master mode).
+    bit_offset: 3
     bit_size: 1
   - name: STOPF
     description: Stop detection (slave mode).
@@ -183,6 +226,14 @@ fieldset/SR1:
     description: PEC Error in reception.
     bit_offset: 12
     bit_size: 1
+  - name: TIMEOUT
+    description: Timeout or Tlow error.
+    bit_offset: 14
+    bit_size: 1
+  - name: SMBALERT
+    description: SMBus alert.
+    bit_offset: 15
+    bit_size: 1
 fieldset/SR2:
   description: Status register 2.
   fields:
@@ -201,6 +252,14 @@ fieldset/SR2:
   - name: GENCALL
     description: General call address (Slave mode).
     bit_offset: 4
+    bit_size: 1
+  - name: SMBDEFAULT
+    description: SMBus device default address.
+    bit_offset: 5
+    bit_size: 1
+  - name: SMBHOST
+    description: SMBus host header.
+    bit_offset: 6
     bit_size: 1
   - name: DUALF
     description: Dual flag (Slave mode).

--- a/data/registers/rcc_f002b.yaml
+++ b/data/registers/rcc_f002b.yaml
@@ -201,6 +201,14 @@ fieldset/APBRSTR2:
     description: ADC reset.
     bit_offset: 20
     bit_size: 1
+  - name: COMP1RST
+    description: COMP1 reset.
+    bit_offset: 21
+    bit_size: 1
+  - name: COMP2RST
+    description: COMP2 reset.
+    bit_offset: 22
+    bit_size: 1
 fieldset/BDCR:
   description: RTC domain control register.
   fields:
@@ -235,6 +243,14 @@ fieldset/BDCR:
 fieldset/CCIPR:
   description: Peripherals independent clock configuration register.
   fields:
+  - name: COMP1SEL
+    description: COMP1 clock source selection.
+    bit_offset: 10
+    bit_size: 1
+  - name: COMP2SEL
+    description: COMP2 clock source selection.
+    bit_offset: 11
+    bit_size: 1
   - name: LPTIM1SEL
     description: LPTIM1 clock source selection.
     bit_offset: 18
@@ -390,6 +406,10 @@ fieldset/ECSCR:
   - name: LSE_DRIVER
     description: desc LSE_DRIVER.
     bit_offset: 16
+    bit_size: 2
+  - name: LSE_STARTUP
+    description: LSE startup time.
+    bit_offset: 20
     bit_size: 2
 fieldset/ICSCR:
   description: Internal clock sources calibration register.

--- a/data/registers/rcc_f072.yaml
+++ b/data/registers/rcc_f072.yaml
@@ -136,8 +136,8 @@ fieldset/APBENR1:
     description: TIM7 timer clock enable.
     bit_offset: 5
     bit_size: 1
-  - name: RTCAPBEN
-    description: RTC APB clock enable.
+  - name: TIMDIV_EN
+    description: "TIMER PCLK frequency control. 0: TIMER PCLK is system PCLK*2, capped at HCLK; 1: TIMER PCLK is system PCLK*1."
     bit_offset: 10
     bit_size: 1
   - name: WWDGEN
@@ -208,7 +208,7 @@ fieldset/APBENR2:
     bit_offset: 9
     bit_size: 1
   - name: DBGEN
-    description: DBG clock enable.
+    description: MCU debug module clock enable.
     bit_offset: 10
     bit_size: 1
   - name: TIM1EN
@@ -346,7 +346,7 @@ fieldset/APBRSTR2:
     bit_offset: 9
     bit_size: 1
   - name: DBGRST
-    description: DBG reset.
+    description: MCU debug module reset.
     bit_offset: 10
     bit_size: 1
   - name: TIM1RST
@@ -496,7 +496,7 @@ fieldset/CFGR:
   - name: MCOSEL
     description: Microcontroller clock output.
     bit_offset: 24
-    bit_size: 3
+    bit_size: 4
     enum: MCOSEL
   - name: MCOPRE
     description: Microcontroller clock output prescaler.
@@ -620,7 +620,7 @@ fieldset/CR:
     description: Clock security system enable.
     bit_offset: 19
     bit_size: 1
-  - name: ADCDIV
+  - name: ADC_DIV
     description: ADC Frequency Division.
     bit_offset: 21
     bit_size: 2
@@ -644,8 +644,8 @@ fieldset/CSR:
     description: LSI oscillator ready.
     bit_offset: 1
     bit_size: 1
-  - name: NRST_FLTDIS
-    description: NRST_FLTDIS oscillator ready.
+  - name: PINRST_FLTDIS
+    description: "NRST 40 us filter disable. 0: filter enabled; 1: filter disabled, reset synchronized to the system clock."
     bit_offset: 8
     bit_size: 1
   - name: RMVF
@@ -872,7 +872,7 @@ enum/PPRE:
     value: 7
 
 enum/MCOSEL:
-  bit_size: 3
+  bit_size: 4
   variants:
   - name: NONE
     description: No clock, MCO output disabled
@@ -880,8 +880,8 @@ enum/MCOSEL:
   - name: SYSCLK
     description: System clock selected
     value: 1
-  - name: RESERVED
-    description: Reserved
+  - name: HSI10M
+    description: HSI 10M clock selected
     value: 2
   - name: HSI
     description: HSI clock selected
@@ -898,6 +898,12 @@ enum/MCOSEL:
   - name: LSE
     description: LSE clock selected
     value: 7
+  - name: HCLK
+    description: HCLK clock selected
+    value: 8
+  - name: PCLK
+    description: PCLK clock selected
+    value: 9
 
 enum/MCOPRE:
   bit_size: 3

--- a/data/registers/spi_v2.yaml
+++ b/data/registers/spi_v2.yaml
@@ -84,8 +84,8 @@ fieldset/CR1:
     bit_offset: 10
     bit_size: 1
     enum: RXONLY
-  - name: DDF
-    description: desc DDF.
+  - name: DFF
+    description: Data frame format.
     bit_offset: 11
     bit_size: 1
   - name: CRCNEXT

--- a/data/registers/syscfg_f072.yaml
+++ b/data/registers/syscfg_f072.yaml
@@ -33,6 +33,10 @@ block/SYSCFG:
     description: desc PFENS.
     byte_offset: 28
     fieldset: PFENS
+  - name: EIIC
+    description: I2C configuration register.
+    byte_offset: 32
+    fieldset: EIIC
 fieldset/CFGR1:
   description: desc CFGR1.
   fields:
@@ -210,4 +214,19 @@ fieldset/PFENS:
   - name: PF_ENS
     description: desc PF_ENS.
     bit_offset: 0
-    bit_size: 16
+    bit_size: 10
+fieldset/EIIC:
+  description: I2C configuration register.
+  fields:
+  - name: PA_EIIC
+    description: EIIC control signal for PA.
+    bit_offset: 0
+    bit_size: 2
+  - name: PB_EIIC
+    description: EIIC control signal for PB.
+    bit_offset: 8
+    bit_size: 8
+  - name: PF_EIIC
+    description: EIIC control signal for PF.
+    bit_offset: 24
+    bit_size: 2

--- a/data/registers/timer_v1.yaml
+++ b/data/registers/timer_v1.yaml
@@ -1346,7 +1346,7 @@ fieldset/RCR_ADV:
   - name: REP
     description: Repetition counter value
     bit_offset: 0
-    bit_size: 16
+    bit_size: 8
 fieldset/SMCR_2CH:
   description: slave mode control register
   fields:

--- a/data/registers/usart_v1.yaml
+++ b/data/registers/usart_v1.yaml
@@ -37,10 +37,10 @@ block/USART:
     description: Control register 3
     byte_offset: 20
     fieldset: CR3_USART
-  # - name: GTPR
-  #   description: Guard time and prescaler register
-  #   byte_offset: 24
-  #   fieldset: GTPR
+  - name: GTPR
+    description: Guard time and prescaler register
+    byte_offset: 24
+    fieldset: GTPR
 fieldset/BRR:
   description: Baud rate register.
   fields:
@@ -126,6 +126,14 @@ fieldset/CR2_USART:
   extends: CR2
   description: Control register 2
   fields:
+  - name: LBDL
+    description: LIN break detection length.
+    bit_offset: 5
+    bit_size: 1
+  - name: LBDIE
+    description: LIN break detection interrupt enable.
+    bit_offset: 6
+    bit_size: 1
   - name: LBCL
     description: Last bit clock pulse.
     bit_offset: 8
@@ -147,8 +155,12 @@ fieldset/CR2_USART:
   - name: STOP
     description: STOP bits.
     bit_offset: 12
-    bit_size: 1
+    bit_size: 2
     enum: STOP
+  - name: LINEN
+    description: LIN mode enable.
+    bit_offset: 14
+    bit_size: 1
 fieldset/CR3:
   description: Control register 3.
   fields:
@@ -264,6 +276,10 @@ fieldset/SR:
     description: Automate baudrate detection requeset.
     bit_offset: 12
     bit_size: 1
+  - name: LBD
+    description: LIN break detection flag.
+    bit_offset: 8
+    bit_size: 1
 enum/CPHA:
   bit_size: 1
   variants:
@@ -328,14 +344,20 @@ enum/RWU:
     description: Receiver in mute mode
     value: 1
 enum/STOP:
-  bit_size: 1
+  bit_size: 2
   variants:
   - name: Stop1
     description: 1 stop bit
     value: 0
+  - name: Stop0P5
+    description: 0.5 stop bits
+    value: 1
   - name: Stop2
     description: 2 stop bits
-    value: 1
+    value: 2
+  - name: Stop1P5
+    description: 1.5 stop bits
+    value: 3
 enum/WAKE:
   bit_size: 1
   variants:
@@ -345,3 +367,14 @@ enum/WAKE:
   - name: AddressMark
     description: USART wakeup on address mark
     value: 1
+fieldset/GTPR:
+  description: Guard time and prescaler register
+  fields:
+  - name: PSC
+    description: Prescaler value.
+    bit_offset: 0
+    bit_size: 8
+  - name: GT
+    description: Guard time value.
+    bit_offset: 8
+    bit_size: 8

--- a/data/registers/usb_v1bits32.yaml
+++ b/data/registers/usb_v1bits32.yaml
@@ -116,7 +116,7 @@ fieldset/EP0CSR:
   - name: COUNT0
     description: COUNT0.
     bit_offset: 8
-    bit_size: 1
+    bit_size: 7
 fieldset/FRAME:
   description: FRAME.
   fields:
@@ -264,7 +264,7 @@ fieldset/OUTCOUNT:
   - name: OUTCOUNT
     description: OUTCOUNT.
     bit_offset: 0
-    bit_size: 10
+    bit_size: 11
 fieldset/OUTEPxCSR:
   description: OUTEPxCSR.
   fields:


### PR DESCRIPTION
claude found some discrepencies, I have not verified them all, but from sampling some it looks like real fixes. Mainly aligning names to what the reference manual calls them, and some bit offset/width inconsistencies