### PR TITLE
Add LPTIM registers

### DIFF
--- a/data/dies/DIE001B/peripherals.yaml
+++ b/data/dies/DIE001B/peripherals.yaml
@@ -101,7 +101,7 @@
   address: 0x40007c00
   registers:
     kind: lptim
-    version: common
+    version: v2
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM

--- a/data/dies/DIE001B/peripherals.yaml
+++ b/data/dies/DIE001B/peripherals.yaml
@@ -105,7 +105,9 @@
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM
-    kernel_clock: PCLK1_TIM
+    kernel_clock:
+      register: CCIPR
+      field: LPTIMSEL
     enable:
       register: APBENR1
       field: LPTIMEN

--- a/data/dies/DIE002B/peripherals.yaml
+++ b/data/dies/DIE002B/peripherals.yaml
@@ -85,7 +85,7 @@
   address: 0x40007c00
   registers:
     kind: lptim
-    version: common
+    version: v2
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM

--- a/data/dies/DIE002B/peripherals.yaml
+++ b/data/dies/DIE002B/peripherals.yaml
@@ -89,7 +89,9 @@
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM
-    kernel_clock: PCLK1_TIM
+    kernel_clock:
+      register: CCIPR
+      field: LPTIMSEL
     enable:
       register: APBENR1
       field: LPTIMEN

--- a/data/dies/DIE030/peripherals.yaml
+++ b/data/dies/DIE030/peripherals.yaml
@@ -201,7 +201,7 @@
   address: 0x40007c00
   registers:
     kind: lptim
-    version: common
+    version: v1
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM

--- a/data/dies/DIE030/peripherals.yaml
+++ b/data/dies/DIE030/peripherals.yaml
@@ -205,7 +205,9 @@
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM
-    kernel_clock: PCLK1_TIM
+    kernel_clock:
+      register: CCIPR
+      field: LPTIMSEL
     enable:
       register: APBENR1
       field: LPTIMEN

--- a/data/dies/DIE072/peripherals.yaml
+++ b/data/dies/DIE072/peripherals.yaml
@@ -406,7 +406,9 @@
     block: LPTIM
   rcc:
     bus_clock: PCLK1_TIM
-    kernel_clock: PCLK1_TIM
+    kernel_clock:
+      register: CCIPR
+      field: LPTIMSEL
     enable:
       register: APBENR1
       field: LPTIMEN

--- a/data/dies/DIE072/peripherals.yaml
+++ b/data/dies/DIE072/peripherals.yaml
@@ -398,12 +398,21 @@
   - signal: GLOBAL
     interrupt: TIM6_LPTIM1_DAC
 
-- name: LPTIM1
+- name: LPTIM
   address: 0x40007c00
   registers:
-    kind: lptim1
-    version: common
-    block: TODO
+    kind: lptim
+    version: v2
+    block: LPTIM
+  rcc:
+    bus_clock: PCLK1_TIM
+    kernel_clock: PCLK1_TIM
+    enable:
+      register: APBENR1
+      field: LPTIMEN
+    reset:
+      register: APBRSTR1
+      field: LPTIMRST
   interrupts:
   - signal: GLOBAL
     interrupt: TIM6_LPTIM1_DAC

--- a/data/registers/lptim_v1.yaml
+++ b/data/registers/lptim_v1.yaml
@@ -1,0 +1,123 @@
+block/LPTIM:
+  description: Low-power timer.
+  items:
+  - name: ISR
+    description: Interrupt and status register.
+    byte_offset: 0
+    access: Read
+    fieldset: ISR
+  - name: ICR
+    description: Interrupt clear register.
+    byte_offset: 4
+    access: Write
+    fieldset: ICR
+  - name: IER
+    description: Interrupt enable register.
+    byte_offset: 8
+    fieldset: IER
+  - name: CFGR
+    description: Configuration register.
+    byte_offset: 12
+    fieldset: CFGR
+  - name: CR
+    description: Control register.
+    byte_offset: 16
+    fieldset: CR
+  - name: ARR
+    description: Auto-reload register.
+    byte_offset: 24
+    fieldset: ARR
+  - name: CNT
+    description: Counter register.
+    byte_offset: 28
+    access: Read
+    fieldset: CNT
+fieldset/ISR:
+  description: Interrupt and status register.
+  fields:
+  - name: ARRM
+    description: Auto-reload match. Set by hardware when CNT matches ARR. Cleared by writing 1 to ICR.ARRMCF.
+    bit_offset: 1
+    bit_size: 1
+fieldset/ICR:
+  description: Interrupt clear register.
+  fields:
+  - name: ARRMCF
+    description: Auto-reload match clear flag. Writing 1 clears ISR.ARRM.
+    bit_offset: 1
+    bit_size: 1
+fieldset/IER:
+  description: Interrupt enable register.
+  fields:
+  - name: ARRMIE
+    description: Auto-reload match interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+fieldset/CFGR:
+  description: Configuration register.
+  fields:
+  - name: PRESC
+    description: Clock prescaler division factor.
+    bit_offset: 9
+    bit_size: 3
+    enum: PRESC
+  - name: PRELOAD
+    description: "Register update mode. 0: ARR is updated after each APB write access; 1: ARR is updated at the end of the current LPTIM cycle."
+    bit_offset: 22
+    bit_size: 1
+fieldset/CR:
+  description: Control register.
+  fields:
+  - name: ENABLE
+    description: LPTIM enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: SNGSTRT
+    description: Start LPTIM in single-pulse mode. Set by software, cleared by hardware; only settable while ENABLE is set.
+    bit_offset: 1
+    bit_size: 1
+  - name: RSTARE
+    description: Reset after read enable. While set, any read of CNT asynchronously resets its contents.
+    bit_offset: 4
+    bit_size: 1
+fieldset/ARR:
+  description: Auto-reload register.
+  fields:
+  - name: ARR
+    description: Auto-reload value. Reset value is 1.
+    bit_offset: 0
+    bit_size: 16
+fieldset/CNT:
+  description: Counter register.
+  fields:
+  - name: CNT
+    description: Counter value. Read twice and compare, since the counter is in a different clock domain.
+    bit_offset: 0
+    bit_size: 16
+enum/PRESC:
+  bit_size: 3
+  variants:
+  - name: DIV1
+    description: Divide by 1
+    value: 0
+  - name: DIV2
+    description: Divide by 2
+    value: 1
+  - name: DIV4
+    description: Divide by 4
+    value: 2
+  - name: DIV8
+    description: Divide by 8
+    value: 3
+  - name: DIV16
+    description: Divide by 16
+    value: 4
+  - name: DIV32
+    description: Divide by 32
+    value: 5
+  - name: DIV64
+    description: Divide by 64
+    value: 6
+  - name: DIV128
+    description: Divide by 128
+    value: 7

--- a/data/registers/lptim_v2.yaml
+++ b/data/registers/lptim_v2.yaml
@@ -1,0 +1,143 @@
+block/LPTIM:
+  description: Low-power timer.
+  items:
+  - name: ISR
+    description: Interrupt and status register.
+    byte_offset: 0
+    access: Read
+    fieldset: ISR
+  - name: ICR
+    description: Interrupt clear register.
+    byte_offset: 4
+    access: Write
+    fieldset: ICR
+  - name: IER
+    description: Interrupt enable register.
+    byte_offset: 8
+    fieldset: IER
+  - name: CFGR
+    description: Configuration register.
+    byte_offset: 12
+    fieldset: CFGR
+  - name: CR
+    description: Control register.
+    byte_offset: 16
+    fieldset: CR
+  - name: ARR
+    description: Auto-reload register.
+    byte_offset: 24
+    fieldset: ARR
+  - name: CNT
+    description: Counter register.
+    byte_offset: 28
+    access: Read
+    fieldset: CNT
+fieldset/ISR:
+  description: Interrupt and status register.
+  fields:
+  - name: ARRM
+    description: Auto-reload match. Set by hardware when CNT matches ARR. Cleared by writing 1 to ICR.ARRMCF.
+    bit_offset: 1
+    bit_size: 1
+  - name: ARROK
+    description: Auto-reload register update OK. Set by hardware once an APB write to ARR has completed. Cleared by writing 1 to ICR.ARROKCF.
+    bit_offset: 4
+    bit_size: 1
+fieldset/ICR:
+  description: Interrupt clear register.
+  fields:
+  - name: ARRMCF
+    description: Auto-reload match clear flag. Writing 1 clears ISR.ARRM.
+    bit_offset: 1
+    bit_size: 1
+  - name: ARROKCF
+    description: Auto-reload register update OK clear flag. Writing 1 clears ISR.ARROK.
+    bit_offset: 4
+    bit_size: 1
+fieldset/IER:
+  description: Interrupt enable register.
+  fields:
+  - name: ARRMIE
+    description: Auto-reload match interrupt enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: ARROKIE
+    description: Auto-reload register update OK interrupt enable.
+    bit_offset: 4
+    bit_size: 1
+fieldset/CFGR:
+  description: Configuration register.
+  fields:
+  - name: PRESC
+    description: Clock prescaler division factor.
+    bit_offset: 9
+    bit_size: 3
+    enum: PRESC
+  - name: PRELOAD
+    description: "Register update mode. 0: ARR is updated after each APB write access; 1: ARR is updated at the end of the current LPTIM cycle."
+    bit_offset: 22
+    bit_size: 1
+fieldset/CR:
+  description: Control register.
+  fields:
+  - name: ENABLE
+    description: LPTIM enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: SNGSTRT
+    description: Start LPTIM in single-pulse mode. Set by software, cleared by hardware; only settable while ENABLE is set.
+    bit_offset: 1
+    bit_size: 1
+  - name: CNTSTRT
+    description: Start LPTIM in continuous mode. Set by software, cleared by hardware; only settable while ENABLE is set.
+    bit_offset: 2
+    bit_size: 1
+  - name: COUNTRST
+    description: Synchronous counter reset. Takes at least three LPTIM clock periods; do not set it again before the previous reset has completed.
+    bit_offset: 3
+    bit_size: 1
+  - name: RSTARE
+    description: Reset after read enable. While set, any read of CNT asynchronously resets its contents.
+    bit_offset: 4
+    bit_size: 1
+fieldset/ARR:
+  description: Auto-reload register.
+  fields:
+  - name: ARR
+    description: Auto-reload value. Reset value is 1.
+    bit_offset: 0
+    bit_size: 16
+fieldset/CNT:
+  description: Counter register.
+  fields:
+  - name: CNT
+    description: Counter value. Read twice and compare, since the counter is in a different clock domain.
+    bit_offset: 0
+    bit_size: 16
+enum/PRESC:
+  bit_size: 3
+  variants:
+  - name: DIV1
+    description: Divide by 1
+    value: 0
+  - name: DIV2
+    description: Divide by 2
+    value: 1
+  - name: DIV4
+    description: Divide by 4
+    value: 2
+  - name: DIV8
+    description: Divide by 8
+    value: 3
+  - name: DIV16
+    description: Divide by 16
+    value: 4
+  - name: DIV32
+    description: Divide by 32
+    value: 5
+  - name: DIV64
+    description: Divide by 64
+    value: 6
+  - name: DIV128
+    description: Divide by 128
+    value: 7

--- a/data/registers/rcc_f002b.yaml
+++ b/data/registers/rcc_f002b.yaml
@@ -235,8 +235,8 @@ fieldset/BDCR:
 fieldset/CCIPR:
   description: Peripherals independent clock configuration register.
   fields:
-  - name: LPTIM1SEL
-    description: LPTIM1 clock source selection.
+  - name: LPTIMSEL
+    description: LPTIM clock source selection.
     bit_offset: 18
     bit_size: 2
 fieldset/CFGR:

--- a/data/registers/rcc_f002b.yaml
+++ b/data/registers/rcc_f002b.yaml
@@ -239,6 +239,7 @@ fieldset/CCIPR:
     description: LPTIM clock source selection.
     bit_offset: 18
     bit_size: 2
+    enum: LPTIMSEL
 fieldset/CFGR:
   description: Clock configuration register.
   fields:
@@ -442,6 +443,21 @@ fieldset/IOPRSTR:
     bit_offset: 2
     bit_size: 1
 
+enum/LPTIMSEL:
+  bit_size: 2
+  variants:
+  - name: PCLK1
+    description: PCLK1 selected as LPTIM clock source
+    value: 0
+  - name: LSI
+    description: LSI selected as LPTIM clock source
+    value: 1
+  - name: DISABLE
+    description: No clock
+    value: 2
+  - name: LSE
+    description: LSE selected as LPTIM clock source
+    value: 3
 enum/SW:
   bit_size: 3
   variants:

--- a/data/registers/rcc_f030.yaml
+++ b/data/registers/rcc_f030.yaml
@@ -335,11 +335,11 @@ fieldset/CCIPR:
     bit_offset: 9
     bit_size: 1
     enum: COMP2SEL
-  - name: LPTIM1SEL
-    description: LPTIM1 clock source selection.
+  - name: LPTIMSEL
+    description: LPTIM clock source selection.
     bit_offset: 18
     bit_size: 2
-    enum: LPTIM1SEL
+    enum: LPTIMSEL
 fieldset/CFGR:
   description: Clock configuration register.
   fields:
@@ -793,20 +793,20 @@ enum/HSE_FREQ:
     description: 16MHz to 32MHz
     value: 3
 
-enum/LPTIM1SEL:
+enum/LPTIMSEL:
   bit_size: 2
   variants:
   - name: PCLK
-    description: PCLK selected as LPTIM1 clock source
+    description: PCLK selected as LPTIM clock source
     value: 0
   - name: LSI
-    description: LSI selected as LPTIM1 clock source
+    description: LSI selected as LPTIM clock source
     value: 1
   - name: NONE
     description: No clock
     value: 2
   - name: LSE
-    description: LSE selected as LPTIM1 clock source
+    description: LSE selected as LPTIM clock source
     value: 3
 
 enum/COMP2SEL:

--- a/data/registers/rcc_f030.yaml
+++ b/data/registers/rcc_f030.yaml
@@ -796,13 +796,13 @@ enum/HSE_FREQ:
 enum/LPTIMSEL:
   bit_size: 2
   variants:
-  - name: PCLK
-    description: PCLK selected as LPTIM clock source
+  - name: PCLK1
+    description: PCLK1 selected as LPTIM clock source
     value: 0
   - name: LSI
     description: LSI selected as LPTIM clock source
     value: 1
-  - name: NONE
+  - name: DISABLE
     description: No clock
     value: 2
   - name: LSE

--- a/data/registers/rcc_f072.yaml
+++ b/data/registers/rcc_f072.yaml
@@ -465,11 +465,11 @@ fieldset/CCIPR:
     bit_offset: 10
     bit_size: 1
     enum: COMPSEL
-  - name: LPTIM1SEL
-    description: LPTIM1 clock source selection.
+  - name: LPTIMSEL
+    description: LPTIM clock source selection.
     bit_offset: 18
     bit_size: 2
-    enum: LPTIM1SEL
+    enum: LPTIMSEL
 fieldset/CFGR:
   description: Clock configuration register.
   fields:
@@ -959,20 +959,20 @@ enum/LSE_DRIVER:
 #     description: 16MHz to 32MHz
 #     value: 3
 
-enum/LPTIM1SEL:
+enum/LPTIMSEL:
   bit_size: 2
   variants:
-  - name: PCLK
-    description: PCLK selected as LPTIM1 clock source
+  - name: PCLK1
+    description: PCLK1 selected as LPTIM clock source
     value: 0
   - name: LSI
-    description: LSI selected as LPTIM1 clock source
+    description: LSI selected as LPTIM clock source
     value: 1
-  - name: NONE
+  - name: DISABLE
     description: No clock
     value: 2
   - name: LSE
-    description: LSE selected as LPTIM1 clock source
+    description: LSE selected as LPTIM clock source
     value: 3
 
 enum/COMPSEL:

--- a/data/registers/rcc_ms32c001b.yaml
+++ b/data/registers/rcc_ms32c001b.yaml
@@ -210,6 +210,7 @@ fieldset/CCIPR:
     description: LPTIM clock source selection
     bit_offset: 18
     bit_size: 2
+    enum: LPTIMSEL
 fieldset/CFGR:
   description: Clock configuration register
   fields:
@@ -408,3 +409,18 @@ fieldset/IOPRSTR:
     description: I/O PortC reset
     bit_offset: 2
     bit_size: 1
+enum/LPTIMSEL:
+  bit_size: 2
+  variants:
+  - name: PCLK1
+    description: PCLK1 selected as LPTIM clock source
+    value: 0
+  - name: LSI
+    description: LSI selected as LPTIM clock source
+    value: 1
+  - name: DISABLE
+    description: No clock
+    value: 2
+  - name: LSE
+    description: LSE selected as LPTIM clock source
+    value: 3

--- a/data/registers/rcc_ms32c001b.yaml
+++ b/data/registers/rcc_ms32c001b.yaml
@@ -206,8 +206,8 @@ fieldset/CCIPR:
     description: PVD module clock source selection
     bit_offset: 7
     bit_size: 1
-  - name: LPTIM1SEL
-    description: LPTIM1 clock source selection
+  - name: LPTIMSEL
+    description: LPTIM clock source selection
     bit_offset: 18
     bit_size: 2
 fieldset/CFGR:


### PR DESCRIPTION
Naming of LPTIM1 vs LPTIM? Reference manual is inconsistent, there are both LPTIM1 and LPTIM namings in the pdf. Need fixes in https://github.com/py32-rs/py32-hal/pull/68 to compile